### PR TITLE
feat: Add Setup method for plugins to inject context and logger

### DIFF
--- a/examples/sample-plugin/harbor/api.go
+++ b/examples/sample-plugin/harbor/api.go
@@ -18,14 +18,15 @@ package harbor
 
 import (
 	"context"
-	"fmt"
 	"os"
 
 	metav1alpha1 "github.com/katanomi/pkg/apis/meta/v1alpha1"
 	"github.com/katanomi/pkg/plugin/client"
+	"go.uber.org/zap"
 )
 
 type harbor struct {
+	*zap.SugaredLogger
 }
 
 func New() *harbor {
@@ -40,18 +41,26 @@ func (h *harbor) Path() string {
 	return "harbor"
 }
 
+func (h *harbor) Setup(ctx context.Context, logger *zap.SugaredLogger) error {
+	// fetch any necessary data from here
+	// client := client.Client(ctx)
+	h.SugaredLogger = logger
+	return nil
+}
+
 func (h *harbor) ListProjects(ctx context.Context, option metav1alpha1.ListOptions) (*metav1alpha1.ProjectList, error) {
 	auth := client.ExtractAuth(ctx)
 
 	basic, err := auth.Basic()
 	if err != nil {
-		fmt.Println("get basic auth error: ", err.Error())
+		h.Infof("get basic auth error: %s", err.Error())
 		return nil, err
 	}
 
 	// list project with harbor api
-
-	fmt.Printf("basic auth: %v", basic)
+	if basic != nil {
+		h.Infof("has basic auth")
+	}
 
 	return nil, nil
 }
@@ -61,13 +70,14 @@ func (h *harbor) CreateProject(ctx context.Context, project *metav1alpha1.Projec
 
 	oauth2, err := auth.Oauth2()
 	if err != nil {
-		fmt.Println("get basic auth error: ", err.Error())
+		h.Infof("get oauth2 auth error: %s", err.Error())
 		return nil, err
 	}
 
 	// create project with harbor api
-
-	fmt.Printf("basic auth: %v", oauth2)
+	if oauth2 != nil {
+		h.Infof("has oauth2 auth")
+	}
 
 	return &metav1alpha1.Project{}, nil
 }
@@ -77,7 +87,7 @@ func (h *harbor) ListResources(ctx context.Context, option metav1alpha1.ListOpti
 
 	// list resource with harbor api
 
-	fmt.Printf("basic auth: %v", meta)
+	h.Infof("meta: %v", meta)
 
 	return nil, nil
 }

--- a/examples/sample-plugin/main.go
+++ b/examples/sample-plugin/main.go
@@ -24,16 +24,6 @@ import (
 )
 
 func main() {
-	/*
-		err := plugin.NewPlugin().WithClient(
-			harbor.New(),
-		).Run()
-
-		if err != nil {
-			fmt.Printf("plugin run err: %s, exit\n", err.Error())
-			os.Exit(1)
-		}
-	*/
 	sharedmain.App("harbor-example").
 		Log().
 		Tracing(nil).

--- a/plugin/client/interface.go
+++ b/plugin/client/interface.go
@@ -26,11 +26,13 @@ import (
 	duckv1 "knative.dev/pkg/apis/duck/v1"
 
 	cloudevent "github.com/cloudevents/sdk-go/v2"
+	"go.uber.org/zap"
 )
 
 // Interface base interface for plugins
 type Interface interface {
 	Path() string
+	Setup(context.Context, *zap.SugaredLogger) error
 }
 
 // PluginRegister plugin registration methods to update IntegationClass status

--- a/plugin/route/route_test.go
+++ b/plugin/route/route_test.go
@@ -29,6 +29,7 @@ import (
 	metav1alpha1 "github.com/katanomi/pkg/apis/meta/v1alpha1"
 	"github.com/katanomi/pkg/plugin/client"
 	. "github.com/onsi/gomega"
+	"go.uber.org/zap"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -238,6 +239,10 @@ func (t *TestProjectList) Path() string {
 	return "test-1"
 }
 
+func (t *TestProjectList) Setup(_ context.Context, _ *zap.SugaredLogger) error {
+	return nil
+}
+
 func (t *TestProjectList) ListProjects(ctx context.Context, option metav1alpha1.ListOptions) (*metav1alpha1.ProjectList, error) {
 	return &metav1alpha1.ProjectList{
 		Items: []metav1alpha1.Project{
@@ -262,6 +267,10 @@ func (t *TestProjectCreate) Path() string {
 	return "test-2"
 }
 
+func (t *TestProjectCreate) Setup(_ context.Context, _ *zap.SugaredLogger) error {
+	return nil
+}
+
 func (t *TestProjectCreate) CreateProject(ctx context.Context, project *metav1alpha1.Project) (*metav1alpha1.Project, error) {
 	return &metav1alpha1.Project{}, nil
 }
@@ -281,6 +290,10 @@ func (t *TestResourceList) Path() string {
 	return "test-3"
 }
 
+func (t *TestResourceList) Setup(_ context.Context, _ *zap.SugaredLogger) error {
+	return nil
+}
+
 func (t *TestResourceList) ListResources(ctx context.Context, option metav1alpha1.ListOptions) (*metav1alpha1.ResourceList, error) {
 	return &metav1alpha1.ResourceList{}, nil
 }
@@ -290,6 +303,10 @@ type TestProjectListCreate struct {
 
 func (t *TestProjectListCreate) Path() string {
 	return "test-4"
+}
+
+func (t *TestProjectListCreate) Setup(_ context.Context, _ *zap.SugaredLogger) error {
+	return nil
 }
 
 func (t *TestProjectListCreate) ListProjects(ctx context.Context, option metav1alpha1.ListOptions) (*metav1alpha1.ProjectList, error) {

--- a/sharedmain/app.go
+++ b/sharedmain/app.go
@@ -327,10 +327,15 @@ func (a *AppBuilder) Webservices(webServices ...WebService) *AppBuilder {
 
 // Plugins adds plugins to this app
 func (a *AppBuilder) Plugins(plugins ...client.Interface) *AppBuilder {
+	// will init a client if not already initiated
+	a.initClient(nil)
 	a.plugins = plugins
 	a.filters = append(a.filters, client.MetaFilter, client.AuthFilter)
 
 	for _, plugin := range a.plugins {
+		if err := plugin.Setup(a.Context, a.Logger); err != nil {
+			a.Logger.Fatalw("plugin could not be setup correctly", "err", err, "plugin", plugin.Path())
+		}
 		ws, err := route.NewService(plugin, a.filters...)
 		if err != nil {
 			a.Logger.Fatalw("plugin could not start correctly", "err", err, "plugin", plugin.Path())


### PR DESCRIPTION
- Add Setup for initialization setup

This is a breaking change to the current Plugin API which
demands implementation of a new method

Affects:

- https://github.com/katanomi/integrations-template
- https://github.com/katanomi/integrations-harbor
- https://github.com/katanomi/integrations-gitlab
- https://github.com/katanomi/integrations-fake

@airycanon @NigelZHANG 

