### PR TITLE
fix: MultiClusterClient leaking token using println

### DIFF
--- a/apis/meta/v1alpha1/labels_annotations_funcs.go
+++ b/apis/meta/v1alpha1/labels_annotations_funcs.go
@@ -1,0 +1,52 @@
+/*
+Copyright 2021 The Katanomi Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha1
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// CopyLabels from the left side object to the righ side
+// will override any existing labels
+func CopyLabels(object, dest metav1.Object) {
+	labels := dest.GetLabels()
+	originalLabels := object.GetLabels()
+	labels = CopyMapStringString(originalLabels, labels)
+	dest.SetLabels(labels)
+}
+
+// CopyAnnotations from the left side object to the righ side
+// will override any existing values
+func CopyAnnotations(object, dest metav1.Object) {
+	anno := dest.GetAnnotations()
+	originalAnno := object.GetAnnotations()
+	anno = CopyMapStringString(originalAnno, anno)
+	dest.SetAnnotations(anno)
+}
+
+// CopyMapStringString copies content from a map to annother
+func CopyMapStringString(object, dest map[string]string) map[string]string {
+	if object != nil {
+		if dest == nil {
+			dest = map[string]string{}
+		}
+		for k, v := range object {
+			dest[k] = v
+		}
+	}
+	return dest
+}

--- a/apis/meta/v1alpha1/labels_annotations_funcs_test.go
+++ b/apis/meta/v1alpha1/labels_annotations_funcs_test.go
@@ -1,0 +1,71 @@
+/*
+Copyright 2021 The Katanomi Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha1
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestCopyLabelsAnnotations(t *testing.T) {
+
+	t.Run("both nil", func(t *testing.T) {
+		g := NewGomegaWithT(t)
+
+		left := &corev1.Secret{}
+		right := &corev1.Secret{}
+		CopyLabels(left, right)
+		CopyAnnotations(left, right)
+		g.Expect(right.Labels).To(BeNil())
+		g.Expect(right.Annotations).To(BeNil())
+	})
+
+	t.Run("left nil, right with value", func(t *testing.T) {
+		g := NewGomegaWithT(t)
+
+		left := &corev1.Secret{}
+		right := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Labels:      map[string]string{"abc": "def"},
+				Annotations: map[string]string{"abc": "def"},
+			},
+		}
+		CopyLabels(left, right)
+		CopyAnnotations(left, right)
+		g.Expect(right.Labels).To(Equal(map[string]string{"abc": "def"}))
+		g.Expect(right.Annotations).To(Equal(map[string]string{"abc": "def"}))
+	})
+
+	t.Run("left with value, right nil", func(t *testing.T) {
+		g := NewGomegaWithT(t)
+
+		left := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Labels:      map[string]string{"xyz": "qwe"},
+				Annotations: map[string]string{"cxz": "dsa"},
+			},
+		}
+		right := &corev1.Secret{}
+		CopyLabels(left, right)
+		CopyAnnotations(left, right)
+		g.Expect(right.Labels).To(Equal(map[string]string{"xyz": "qwe"}))
+		g.Expect(right.Annotations).To(Equal(map[string]string{"cxz": "dsa"}))
+	})
+}

--- a/multicluster/clusterregistry_client.go
+++ b/multicluster/clusterregistry_client.go
@@ -21,7 +21,6 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"errors"
-	"fmt"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -175,7 +174,6 @@ func (m *ClusterRegistryClient) getConfigFromCluster(ctx context.Context, cluste
 			return
 		}
 		token, ok, secretErr := unstructured.NestedString(secretObj.Object, "data", "token")
-		fmt.Println("data.token", token, "ok", ok)
 		if secretErr != nil {
 			err = secretErr
 			return

--- a/namespace/context.go
+++ b/namespace/context.go
@@ -1,0 +1,40 @@
+/*
+Copyright 2021 The Katanomi Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package namespace
+
+import (
+	"context"
+)
+
+type namespaceKey struct{}
+
+// WithNamespace returns a copy of parent in which the namespace value is set
+func WithNamespace(parent context.Context, namespace string) context.Context {
+	return context.WithValue(parent, namespaceKey{}, namespace)
+}
+
+// NamespaceFrom returns the value of the namespace key on the ctx
+func NamespaceFrom(ctx context.Context) (string, bool) {
+	namespace, ok := ctx.Value(namespaceKey{}).(string)
+	return namespace, ok
+}
+
+// NamespaceValue returns the value of the namespace key on the ctx, or the empty string if none
+func NamespaceValue(ctx context.Context) string {
+	namespace, _ := NamespaceFrom(ctx)
+	return namespace
+}

--- a/namespace/context_test.go
+++ b/namespace/context_test.go
@@ -1,0 +1,45 @@
+/*
+Copyright 2021 The Katanomi Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package namespace
+
+import (
+	"context"
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	. "github.com/onsi/gomega"
+)
+
+func TestNamespaceContext(t *testing.T) {
+	g := NewGomegaWithT(t)
+	ctrl := gomock.NewController(t)
+
+	defer ctrl.Finish()
+
+	ctx := context.TODO()
+
+	ns, ok := NamespaceFrom(ctx)
+	g.Expect(ok).To(BeFalse())
+	g.Expect(ns).To(BeEmpty())
+
+	ctx = WithNamespace(ctx, "abc")
+
+	g.Expect(NamespaceValue(ctx)).To(Equal("abc"))
+	ns, ok = NamespaceFrom(ctx)
+	g.Expect(ok).To(BeTrue())
+	g.Expect(ns).To(Equal("abc"))
+}


### PR DESCRIPTION
- Removes the fmt.Println entry leaking values in MultiClientCluster
- Adds CopyLabels and CopyAnnotations quick helpers
- Adds Namespace context methods