### PR TITLE
feat: Change the client.Manager filter to be strict require token

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ bin
 
 .DS_Store
 
+*.xml

--- a/client/bearer_token.go
+++ b/client/bearer_token.go
@@ -20,6 +20,7 @@ import (
 	"strings"
 
 	"github.com/emicklei/go-restful/v3"
+	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/client-go/tools/clientcmd/api"
@@ -44,6 +45,10 @@ func FromBearerToken(req *restful.Request, baseConfig GetBaseConfigFunc) (config
 		return
 	}
 	token := GetToken(req)
+	if strings.TrimSpace(token) == "" {
+		err = errors.NewUnauthorized("a Bearer token must be provided")
+		return
+	}
 	cmd := BuildCmdConfig(&api.AuthInfo{Token: token}, config)
 	config, err = cmd.ClientConfig()
 	return

--- a/client/manager_test.go
+++ b/client/manager_test.go
@@ -49,7 +49,7 @@ func TestManagerFilter(t *testing.T) {
 		req.Request = req.Request.WithContext(ctx)
 		resp := restful.NewResponse(httptest.NewRecorder())
 
-		ManagerFilter(mgr)(req, resp, chain)
+		ManagerFilter(ctx, mgr)(req, resp, chain)
 
 		config := injection.GetConfig(req.Request.Context())
 		g.Expect(config).ToNot(BeNil())
@@ -67,8 +67,8 @@ func TestManagerFilter(t *testing.T) {
 		req := restful.NewRequest(httptest.NewRequest(http.MethodGet, "http://example.com", nil))
 		req.Request = req.Request.WithContext(ctx)
 		resp := restful.NewResponse(httptest.NewRecorder())
-		ManagerFilter(mgr)(req, resp, chain)
-		g.Expect(resp.StatusCode()).To(Equal(http.StatusInternalServerError))
+		ManagerFilter(ctx, mgr)(req, resp, chain)
+		g.Expect(resp.StatusCode()).To(Equal(http.StatusUnauthorized))
 		config := injection.GetConfig(req.Request.Context())
 		g.Expect(config).To(BeNil())
 	})

--- a/sharedmain/app.go
+++ b/sharedmain/app.go
@@ -128,7 +128,7 @@ func (a *AppBuilder) init() {
 
 		a.container = restful.NewContainer()
 		a.Context, a.ClientManager = GetClientManager(a.Context)
-		a.filters = []restful.FilterFunction{a.ClientManager.Filter()}
+		a.filters = []restful.FilterFunction{}
 	})
 }
 


### PR DESCRIPTION
When not providing a Bearer token the default implementation of Manager
will return a 401 Unauthorized error. The token contents are currently
not validated. With this change the Manager filter was removed from
AppBuilder as default filter to avoid other conflicts and needs to be
initiated manually in specific Webservices with the following snipet:

```golang
// inside Webservice Setup method
ws := &restful.WebService{}
if manager := client.ManagerCtx(ctx); manager != nil {
	ws = ws.Filter(manager.Filter(ctx))
}
```