### PR TITLE
feat: Add Defaulting (Mutating) webhook with transforms and context

### DIFF
--- a/apis/meta/v1alpha1/triggeredby_types.go
+++ b/apis/meta/v1alpha1/triggeredby_types.go
@@ -45,6 +45,14 @@ type TriggeredBy struct {
 	TriggeredTimestamp *metav1.Time `json:"triggeredTimestamp,omitempty"`
 }
 
+// IsZero basic function returns true when all attributes of the object are empty
+func (by TriggeredBy) IsZero() bool {
+	return by.User == nil &&
+		by.CloudEvent == nil &&
+		by.Ref == nil &&
+		by.TriggeredTimestamp == nil
+}
+
 // FromAnnotation will set `by` from annotations
 // it will find TriggeredByAnnotationKey and unmarshl content into struct type *TriggeredBy
 // if not found TriggeredByAnnotationKey, error would be nil, and *TriggeredBy would be nil also.

--- a/multicluster/interface.go
+++ b/multicluster/interface.go
@@ -28,7 +28,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-//go:generate mockgen -package=multicluster -destination=../testing/mock/github.com/katanomi/pkg/multicluster/interface.go  github.com/katanomi/pkg/multicluster Interface
+//go:generate ../bin/mockgen -package=multicluster -destination=../testing/mock/github.com/katanomi/pkg/multicluster/interface.go  github.com/katanomi/pkg/multicluster Interface
 
 // Interface interface for a multi-cluster functionality
 type Interface interface {

--- a/testing/mock/github.com/katanomi/pkg/multicluster/interface.go
+++ b/testing/mock/github.com/katanomi/pkg/multicluster/interface.go
@@ -10,6 +10,7 @@ import (
 
 	gomock "github.com/golang/mock/gomock"
 	v1 "k8s.io/api/core/v1"
+	unstructured "k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	dynamic "k8s.io/client-go/dynamic"
 	rest "k8s.io/client-go/rest"
@@ -69,6 +70,21 @@ func (mr *MockInterfaceMockRecorder) GetConfig(arg0, arg1 interface{}) *gomock.C
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetConfig", reflect.TypeOf((*MockInterface)(nil).GetConfig), arg0, arg1)
 }
 
+// GetConfigFromCluster mocks base method.
+func (m *MockInterface) GetConfigFromCluster(arg0 context.Context, arg1 *unstructured.Unstructured) (*rest.Config, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetConfigFromCluster", arg0, arg1)
+	ret0, _ := ret[0].(*rest.Config)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetConfigFromCluster indicates an expected call of GetConfigFromCluster.
+func (mr *MockInterfaceMockRecorder) GetConfigFromCluster(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetConfigFromCluster", reflect.TypeOf((*MockInterface)(nil).GetConfigFromCluster), arg0, arg1)
+}
+
 // GetDynamic mocks base method.
 func (m *MockInterface) GetDynamic(arg0 context.Context, arg1 *v1.ObjectReference) (dynamic.Interface, error) {
 	m.ctrl.T.Helper()
@@ -82,4 +98,19 @@ func (m *MockInterface) GetDynamic(arg0 context.Context, arg1 *v1.ObjectReferenc
 func (mr *MockInterfaceMockRecorder) GetDynamic(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDynamic", reflect.TypeOf((*MockInterface)(nil).GetDynamic), arg0, arg1)
+}
+
+// ListClustersNamespaces mocks base method.
+func (m *MockInterface) ListClustersNamespaces(arg0 context.Context, arg1 string) (map[*v1.ObjectReference][]v1.Namespace, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListClustersNamespaces", arg0, arg1)
+	ret0, _ := ret[0].(map[*v1.ObjectReference][]v1.Namespace)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListClustersNamespaces indicates an expected call of ListClustersNamespaces.
+func (mr *MockInterfaceMockRecorder) ListClustersNamespaces(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListClustersNamespaces", reflect.TypeOf((*MockInterface)(nil).ListClustersNamespaces), arg0, arg1)
 }

--- a/webhook/admission/context.go
+++ b/webhook/admission/context.go
@@ -1,0 +1,39 @@
+/*
+Copyright 2021 The Katanomi Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package admission
+
+import (
+	"context"
+
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+)
+
+type admissionReqKey struct{}
+
+// WithAdmissionRequest adds an admission request to the context
+func WithAdmissionRequest(ctx context.Context, req admission.Request) context.Context {
+	return context.WithValue(ctx, admissionReqKey{}, req)
+}
+
+// AdmissionRequest returns admission request from context
+func AdmissionRequest(ctx context.Context) admission.Request {
+	val := ctx.Value(admissionReqKey{})
+	if val == nil {
+		return admission.Request{}
+	}
+	return val.(admission.Request)
+}

--- a/webhook/admission/defaulter.go
+++ b/webhook/admission/defaulter.go
@@ -1,0 +1,111 @@
+/*
+Copyright 2021 The Katanomi Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package admission
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+
+	"go.uber.org/zap"
+	admissionv1 "k8s.io/api/admission/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"knative.dev/pkg/apis"
+	"knative.dev/pkg/logging"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+)
+
+// Defaulter defines functions for setting defaults on resources
+type Defaulter interface {
+	runtime.Object
+	metav1.Object
+	Default(context.Context)
+}
+
+// DefaultingWebhookFor creates a new Webhook for Defaulting the provided type.
+func DefaultingWebhookFor(ctx context.Context, defaulter Defaulter, transforms ...TransformFunc) *admission.Webhook {
+	return &admission.Webhook{
+		Handler: &mutatingHandler{
+			defaulter:     defaulter,
+			transforms:    transforms,
+			SugaredLogger: logging.FromContext(ctx),
+		},
+	}
+}
+
+type mutatingHandler struct {
+	defaulter  Defaulter
+	decoder    *admission.Decoder
+	transforms []TransformFunc
+
+	*zap.SugaredLogger
+}
+
+var _ admission.DecoderInjector = &mutatingHandler{}
+
+// InjectDecoder injects the decoder into a mutatingHandler.
+func (h *mutatingHandler) InjectDecoder(d *admission.Decoder) error {
+	h.decoder = d
+	return nil
+}
+
+// Handle handles admission requests.
+func (h *mutatingHandler) Handle(ctx context.Context, req admission.Request) admission.Response {
+	if h.defaulter == nil {
+		panic("defaulter should never be nil")
+	}
+
+	ctx = logging.WithLogger(ctx, h.SugaredLogger)
+	ctx = WithAdmissionRequest(ctx, req)
+
+	// Get the object in the request
+	obj := h.defaulter.DeepCopyObject().(Defaulter)
+	err := h.decoder.Decode(req, obj)
+	if err != nil {
+		return admission.Errored(http.StatusBadRequest, err)
+	}
+
+	switch req.Operation {
+	case admissionv1.Create:
+		ctx = apis.WithinCreate(ctx)
+	case admissionv1.Update:
+		old := h.defaulter.DeepCopyObject()
+		err := h.decoder.DecodeRaw(req.OldObject, old)
+		if err != nil {
+			return admission.Errored(http.StatusBadRequest, err)
+		}
+		ctx = apis.WithinUpdate(ctx, old)
+	case admissionv1.Delete:
+		ctx = apis.WithinDelete(ctx)
+	}
+
+	// apply some common transformations before handling defaults
+	for _, transform := range h.transforms {
+		transform(ctx, obj, req)
+	}
+
+	// Default the object
+	obj.Default(ctx)
+	marshalled, err := json.Marshal(obj)
+	if err != nil {
+		return admission.Errored(http.StatusInternalServerError, err)
+	}
+
+	// Create the patch
+	return admission.PatchResponseFromRaw(req.Object.Raw, marshalled)
+}

--- a/webhook/admission/funcs.go
+++ b/webhook/admission/funcs.go
@@ -1,0 +1,44 @@
+/*
+Copyright 2021 The Katanomi Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package admission
+
+import (
+	"strings"
+
+	rbacv1 "k8s.io/api/rbac/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+)
+
+func generateMutatePath(gvk schema.GroupVersionKind) string {
+	return "/mutate-" + strings.Replace(gvk.Group, ".", "-", -1) + "-" +
+		gvk.Version + "-" + strings.ToLower(gvk.Kind)
+}
+
+// returns a user based on the request information
+func SubjectFromRequest(req admission.Request) *rbacv1.Subject {
+	sub := &rbacv1.Subject{}
+	if strings.HasPrefix(req.UserInfo.Username, "system:serviceaccount:") {
+		sub.Kind = rbacv1.ServiceAccountKind
+	} else {
+		// all non-service accounts are treated as users
+		sub.Kind = rbacv1.UserKind
+
+	}
+	sub.Name = req.UserInfo.Username
+	return sub
+}

--- a/webhook/admission/register.go
+++ b/webhook/admission/register.go
@@ -1,0 +1,38 @@
+/*
+Copyright 2021 The Katanomi Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package admission
+
+import (
+	"context"
+
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
+)
+
+// RegisterDefaultWebhookFor registers a mutate webhook for the defaulter with transforms
+func RegisterDefaultWebhookFor(ctx context.Context, mgr ctrl.Manager, defaulter Defaulter, transforms ...TransformFunc) (err error) {
+	var gvk schema.GroupVersionKind
+	if gvk, err = apiutil.GVKForObject(defaulter, mgr.GetScheme()); err != nil {
+		return
+	}
+	mgr.GetWebhookServer().Register(
+		generateMutatePath(gvk),
+		DefaultingWebhookFor(ctx, defaulter, transforms...),
+	)
+	return
+}

--- a/webhook/admission/transform.go
+++ b/webhook/admission/transform.go
@@ -1,0 +1,71 @@
+/*
+Copyright 2021 The Katanomi Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package admission
+
+import (
+	"context"
+
+	mv1alpha1 "github.com/katanomi/pkg/apis/meta/v1alpha1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"knative.dev/pkg/logging"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+)
+
+// TransformFuncused to make common defaulting logic amongst multiple resource
+// using a context, an object and a request
+type TransformFunc func(context.Context, runtime.Object, admission.Request)
+
+// WithTriggeredBy adds a triggeredBy annotation to the object using the request information
+// when an object already has the triggeredBy annotation it will only increment missing data
+func WithTriggeredBy() TransformFunc {
+	return func(ctx context.Context, obj runtime.Object, req admission.Request) {
+		metaobj, ok := obj.(metav1.Object)
+		if !ok {
+			return
+		}
+		log := logging.FromContext(ctx)
+		annotations := metaobj.GetAnnotations()
+		if annotations == nil {
+			annotations = map[string]string{}
+		}
+
+		var err error
+		triggeredBy := &mv1alpha1.TriggeredBy{}
+		triggeredBy, err = triggeredBy.FromAnnotation(annotations)
+		if err != nil {
+			log.Warnw("cannot unmarshal annotation value into triggeredBy struct", "err", err)
+		}
+		if triggeredBy == nil {
+			triggeredBy = &mv1alpha1.TriggeredBy{}
+		}
+
+		if triggeredBy.User == nil || triggeredBy.User.Name == "" {
+			triggeredBy.User = SubjectFromRequest(req)
+		}
+		if triggeredBy.TriggeredTimestamp == nil {
+			creation := metaobj.GetCreationTimestamp()
+			triggeredBy.TriggeredTimestamp = &creation
+		}
+		annotations, err = triggeredBy.SetIntoAnnotation(annotations)
+		if err != nil {
+			log.Warnw("cannot marshal triggeredBy struct to json ", "err", err, "struct", triggeredBy)
+		} else {
+			metaobj.SetAnnotations(annotations)
+		}
+	}
+}


### PR DESCRIPTION
Enables a more complex and feature rich Default method for types
to provide a context parameter in the Default function. This context
will be populated using knative/pkg/apis methods and also includes the
request object for further processing