### PR TITLE
feat: Add RBAC filter for APIs using meta.katanomi.dev

### DIFF
--- a/apis/meta/v1alpha1/artifact_types.go
+++ b/apis/meta/v1alpha1/artifact_types.go
@@ -17,6 +17,7 @@ limitations under the License.
 package v1alpha1
 
 import (
+	authv1 "k8s.io/api/authorization/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	duckv1 "knative.dev/pkg/apis/duck/v1"
@@ -65,4 +66,14 @@ type ArtifactList struct {
 	ListMeta        `json:"metadata,omitempty"`
 
 	Items []Artifact `json:"items"`
+}
+
+// ArtifactResourceAttributes returns a ResourceAttribute object to be used in a filter
+func ArtifactResourceAttributes(verb string) authv1.ResourceAttributes {
+	return authv1.ResourceAttributes{
+		Group:    GroupVersion.Group,
+		Version:  GroupVersion.Version,
+		Resource: "artifacts",
+		Verb:     verb,
+	}
 }

--- a/apis/meta/v1alpha1/gitrepositories_types.go
+++ b/apis/meta/v1alpha1/gitrepositories_types.go
@@ -17,6 +17,7 @@ limitations under the License.
 package v1alpha1
 
 import (
+	authv1 "k8s.io/api/authorization/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 )
@@ -59,4 +60,15 @@ type GitRepositoryList struct {
 	ListMeta        `json:"metadata,omitempty"`
 
 	Items []GitRepository `json:"items"`
+}
+
+// GitRepositoryResourceAttributes returns a ResourceAttribute object to be used in a filter
+func GitRepositoryResourceAttributes(verb string) authv1.ResourceAttributes {
+	return authv1.ResourceAttributes{
+		Group:   GroupVersion.Group,
+		Version: GroupVersion.Version,
+		// TODO: modify accordingly
+		Resource: "gitrepositories",
+		Verb:     verb,
+	}
 }

--- a/apis/meta/v1alpha1/repository_types.go
+++ b/apis/meta/v1alpha1/repository_types.go
@@ -20,6 +20,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	duckv1 "knative.dev/pkg/apis/duck/v1"
+
+	authv1 "k8s.io/api/authorization/v1"
 )
 
 var RepositoryGVK = GroupVersion.WithKind("Repository")
@@ -62,4 +64,14 @@ type RepositoryList struct {
 	ListMeta        `json:"metadata,omitempty"`
 
 	Items []Repository `json:"items"`
+}
+
+// RepositoryResourceAttributes returns a ResourceAttribute object to be used in a filter
+func RepositoryResourceAttributes(verb string) authv1.ResourceAttributes {
+	return authv1.ResourceAttributes{
+		Group:    GroupVersion.Group,
+		Version:  GroupVersion.Version,
+		Resource: "repositories",
+		Verb:     verb,
+	}
 }

--- a/client/defaults.go
+++ b/client/defaults.go
@@ -1,0 +1,25 @@
+/*
+Copyright 2021 The Katanomi Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package client
+
+import "time"
+
+var (
+	DefaultTimeout         = 10 * time.Second
+	DefaultQPS     float32 = 50.0
+	DefaultBurst           = 60
+)

--- a/client/rbac_filter.go
+++ b/client/rbac_filter.go
@@ -1,0 +1,98 @@
+/*
+Copyright 2021 The Katanomi Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package client
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/emicklei/go-restful/v3"
+	authv1 "k8s.io/api/authorization/v1"
+	"knative.dev/pkg/logging"
+
+	// metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	kerrors "github.com/katanomi/pkg/errors"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+// SelfSubjectReviewFilterForResource makes a self subject review based a configuration already present inside the
+// request context using the user's bearer token
+func SelfSubjectReviewFilterForResource(ctx context.Context, resourceAtt authv1.ResourceAttributes, namespaceParameter, nameParameter string) restful.FilterFunction {
+	return func(req *restful.Request, resp *restful.Response, chain *restful.FilterChain) {
+		ctx := req.Request.Context()
+		log := logging.FromContext(ctx).With("resource", resourceAtt.Resource, "group", resourceAtt.Group, "verb", resourceAtt.Verb)
+		ctx = logging.WithLogger(ctx, log)
+		err := SelfSubjectAccessReviewForResource(ctx, req.PathParameter(nameParameter), req.PathParameter(namespaceParameter), resourceAtt, false)
+		if err != nil {
+			log.Debugw("error veryfing user permissions", "err", err)
+			kerrors.HandleError(req, resp, err)
+			return
+		}
+		chain.ProcessFilter(req, resp)
+	}
+}
+
+func SelfSubjectAccessReviewForResource(ctx context.Context, name, namespace string, resourceAtt authv1.ResourceAttributes, addName bool) (err error) {
+	log := logging.FromContext(ctx)
+	clt := Client(ctx)
+	if clt == nil {
+		// return error
+		log.Debugw("error fetching the client from the context. Make sure the ManagerFilter is added before this filter")
+		// return internal server error
+		err = errors.NewUnauthorized("SelfSubjectReview needs user's client")
+		return
+	}
+	if namespace != "" {
+		resourceAtt.Namespace = namespace
+	}
+	if name != "" {
+		resourceAtt.Name = name
+	}
+
+	review := &authv1.SelfSubjectAccessReview{
+		Spec: authv1.SelfSubjectAccessReviewSpec{
+			ResourceAttributes: &resourceAtt,
+		},
+	}
+	// this is only to be used within tests
+	// the fake client somehow requests the name
+	if addName {
+		review.Name = resourceAtt.Name
+		review.Namespace = resourceAtt.Namespace
+	}
+	err = clt.Create(ctx, review)
+	if err != nil {
+		log.Errorw("error evaluating SelfSubjectReview", "err", err)
+		return
+	}
+
+	log.Debug("checking user permission against the resource",
+		"allowed", review.Status.Allowed,
+		"reason", review.Status.Reason,
+		"evError", review.Status.EvaluationError,
+	)
+
+	if !review.Status.Allowed {
+		err = errors.NewForbidden(schema.GroupResource{
+			Group:    resourceAtt.Group,
+			Resource: resourceAtt.Resource,
+		}, resourceAtt.Name, fmt.Errorf("access not allowed"))
+		return
+	}
+	return
+}

--- a/client/rbac_filter_test.go
+++ b/client/rbac_filter_test.go
@@ -1,0 +1,63 @@
+/*
+Copyright 2021 The Katanomi Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package client
+
+import (
+	"context"
+
+	"testing"
+
+	. "github.com/onsi/gomega"
+	authv1 "k8s.io/api/authorization/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func TestRBACFilter(t *testing.T) {
+
+	scheme := runtime.NewScheme()
+	authv1.AddToScheme(scheme)
+
+	attr := authv1.ResourceAttributes{
+		Namespace: "default",
+		Verb:      "update",
+		Group:     "meta.katanomi.dev",
+		Version:   "v1alpha1",
+		Resource:  "artifacts",
+		Name:      "abc",
+	}
+	t.Run("no client in request", func(t *testing.T) {
+		g := NewGomegaWithT(t)
+		ctx := context.TODO()
+
+		err := SelfSubjectAccessReviewForResource(ctx, "def", "default", attr, true)
+		g.Expect(err).ToNot(BeNil())
+		g.Expect(errors.IsUnauthorized(err)).To(BeTrue())
+
+	})
+	t.Run("adding fake client in request", func(t *testing.T) {
+		g := NewGomegaWithT(t)
+		ctx := context.TODO()
+		clt := fake.NewClientBuilder().WithScheme(scheme).Build()
+		ctx = WithClient(ctx, clt)
+
+		err := SelfSubjectAccessReviewForResource(ctx, "xyz", "default", attr, true)
+		g.Expect(err).ToNot(BeNil())
+		g.Expect(errors.IsForbidden(err)).To(BeTrue())
+	})
+}

--- a/sharedmain/app.go
+++ b/sharedmain/app.go
@@ -62,9 +62,9 @@ import (
 )
 
 var (
-	DefaultTimeout         = 10 * time.Second
-	DefaultQPS     float32 = 50.0
-	DefaultBurst           = 60
+	DefaultTimeout = kclient.DefaultTimeout
+	DefaultQPS     = kclient.DefaultQPS
+	DefaultBurst   = kclient.DefaultBurst
 )
 
 // AppBuilder builds an app using multiple configuration options


### PR DESCRIPTION
- Adds client to be initiated in Manager filter
- Move config defaults to client package
- Adds RBAC SelfSubjectReview to check permissions