### PR TITLE
fix:support GetGitRepository use subgroup

### DIFF
--- a/plugin/route/artifact.go
+++ b/plugin/route/artifact.go
@@ -44,7 +44,7 @@ func (a *artifactList) Register(ws *restful.WebService) {
 	repositoryParam := ws.PathParameter("repository", "artifact belong to repository")
 	ws.Route(
 		ListOptionsDocs(
-			ws.GET("/projects/{project}/repositories/{repository:*}/artifacts").To(a.ListArtifacts).
+			ws.GET("/projects/{project:*}/repositories/{repository:*}/artifacts").To(a.ListArtifacts).
 				// docs
 				Doc("ListArtifacts").Param(projectParam).Param(repositoryParam).
 				Metadata(restfulspec.KeyOpenAPITags, a.tags).
@@ -88,7 +88,7 @@ func (a *artifactGetter) Register(ws *restful.WebService) {
 	repositoryParam := ws.PathParameter("repository", "artifact belong to repository")
 	artifactParam := ws.PathParameter("artifact", "artifact name, maybe is version or tag")
 	ws.Route(
-		ws.GET("/projects/{project}/repositories/{repository:*}/artifacts/{artifact}").To(a.GetArtifact).
+		ws.GET("/projects/{project:*}/repositories/{repository:*}/artifacts/{artifact}").To(a.GetArtifact).
 			// docs
 			Doc("GetArtifact").Param(projectParam).Param(repositoryParam).Param(artifactParam).
 			Metadata(restfulspec.KeyOpenAPITags, a.tags).
@@ -132,7 +132,7 @@ func (a *artifactDeleter) Register(ws *restful.WebService) {
 	repositoryParam := ws.PathParameter("repository", "artifact belong to repository")
 	artifactParam := ws.PathParameter("artifact", "artifact name, maybe is version or tag")
 	ws.Route(
-		ws.DELETE("/projects/{project}/repositories/{repository:*}/artifacts/{artifact}").To(a.DeleteArtifact).
+		ws.DELETE("/projects/{project:*}/repositories/{repository:*}/artifacts/{artifact}").To(a.DeleteArtifact).
 			// docs
 			Doc("DeleteArtifact").Param(projectParam).Param(repositoryParam).Param(artifactParam).
 			Metadata(restfulspec.KeyOpenAPITags, a.tags).
@@ -176,7 +176,7 @@ func (s *scanImage) Register(ws *restful.WebService) {
 	repositoryParam := ws.PathParameter("repository", "artifact belong to repository")
 	artifactParam := ws.PathParameter("artifact", "artifact name, maybe is version or tag")
 	ws.Route(
-		ws.POST("/projects/{project}/repositories/{repository:*}/artifacts/{artifact}/scan").To(s.ScanImage).
+		ws.POST("/projects/{project:*}/repositories/{repository:*}/artifacts/{artifact}/scan").To(s.ScanImage).
 			// docs
 			Doc("ScanImage").Param(projectParam).Param(repositoryParam).Param(artifactParam).
 			Metadata(restfulspec.KeyOpenAPITags, s.tags).

--- a/plugin/route/artifact_test.go
+++ b/plugin/route/artifact_test.go
@@ -1,0 +1,83 @@
+/*
+Copyright 2021 The Katanomi Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package route
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/katanomi/pkg/plugin/client"
+
+	"github.com/emicklei/go-restful/v3"
+	metav1alpha1 "github.com/katanomi/pkg/apis/meta/v1alpha1"
+	. "github.com/onsi/gomega"
+	"go.uber.org/zap"
+)
+
+func TestListArtifacts(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	ws, err := NewService(&TestListArtifact{}, client.MetaFilter)
+	g.Expect(err).To(BeNil())
+
+	var projects = []string{
+		"proj",
+		"proj%2Fsub",
+		"repositories",
+	}
+
+	container := restful.NewContainer()
+	container.Router(restful.RouterJSR311{})
+	container.Add(ws)
+	for _, project := range projects {
+		path := fmt.Sprintf("/plugins/v1alpha1/test-artifacts-1/projects/%s/repositories/katanomi/artifacts", project)
+		httpRequest, _ := http.NewRequest("GET", path, nil)
+		httpRequest.Header.Set("Accept", "application/json")
+
+		metaData := client.Meta{BaseURL: "http://api.test", Version: "v1"}
+		data, _ := json.Marshal(metaData)
+		meta := base64.StdEncoding.EncodeToString(data)
+		httpRequest.Header.Set(client.PluginMetaHeader, meta)
+		httpWriter := httptest.NewRecorder()
+		container.Dispatch(httpWriter, httpRequest)
+		g.Expect(httpWriter.Code).To(Equal(http.StatusOK))
+
+		branchList := metav1alpha1.GitBranchList{}
+		err = json.Unmarshal(httpWriter.Body.Bytes(), &branchList)
+		g.Expect(err).To(BeNil())
+	}
+}
+
+type TestListArtifact struct {
+}
+
+func (t *TestListArtifact) Path() string {
+	return "test-artifacts-1"
+}
+
+func (t *TestListArtifact) Setup(_ context.Context, _ *zap.SugaredLogger) error {
+	return nil
+}
+
+func (t *TestListArtifact) ListArtifacts(ctx context.Context, params metav1alpha1.ArtifactOptions, option metav1alpha1.ListOptions) (*metav1alpha1.ArtifactList, error) {
+	return &metav1alpha1.ArtifactList{}, nil
+}

--- a/plugin/route/gitrepository.go
+++ b/plugin/route/gitrepository.go
@@ -98,7 +98,7 @@ func (a *gitRepositoryGetter) Register(ws *restful.WebService) {
 	repositoryParam := ws.PathParameter("repository", "repository name")
 	projectParam := ws.PathParameter("project", "repository belong to project")
 	ws.Route(
-		ws.GET("/projects/{project}/coderepositories/{repository}").To(a.GetGitRepository).
+		ws.GET("/projects/{project:*}/coderepositories/{repository}").To(a.GetGitRepository).
 			Doc("GetGitRepo").Param(projectParam).Param(repositoryParam).
 			Metadata(restfulspec.KeyOpenAPITags, a.tags).
 			Returns(http.StatusOK, "OK", metav1alpha1.GitRepository{}),

--- a/plugin/route/project.go
+++ b/plugin/route/project.go
@@ -118,8 +118,8 @@ func NewProjectGet(impl client.ProjectGetter) Route {
 }
 
 func (p *projectGet) Register(ws *restful.WebService) {
-	ws.Route(ws.GET("/projects/{project-id:*}").To(p.GetProject).
-		Param(ws.PathParameter("project-id", "identifier of the project").DataType("string")).
+	ws.Route(ws.GET("/projects/{project:*}").To(p.GetProject).
+		Param(ws.PathParameter("project", "identifier of the project").DataType("string")).
 		Param(ws.QueryParameter("type", "subtype of the project").DataType("string")).
 		// docs
 		Doc("GetProject").
@@ -130,7 +130,7 @@ func (p *projectGet) Register(ws *restful.WebService) {
 
 // GetProject http handler for get project
 func (p *projectGet) GetProject(request *restful.Request, response *restful.Response) {
-	id := request.PathParameter("project-id")
+	id := request.PathParameter("project")
 	projectSubtype := request.QueryParameter("type")
 
 	ctx := context.WithValue(request.Request.Context(), metav1alpha1.KeyForSubType, projectSubtype)


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Unified routing parameters (project) use the format {project:*}

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [√] [`spec` PR link](https://github.com/katanomi/spec) included(API not change)
- [√] Follows the [commit message standard](https://github.com/katanomi/spec/blob/main/CONTRIBUTING.md#commits)
- [√] Meets the [contributing guidelines](https://github.com/katanomi/spec/blob/main/CONTRIBUTING.md) (including
  functionality, content, code)
- [√] Test cases with documentation and functionality works as expected using current and related github repos (MUST deploy and check)
- [√] Release notes block below has been filled in or deleted (only if no user facing changes)

# Release Notes

Bug fixes

```release-note
Unified routing parameters (project) use the format {project:*}
```
