### PR TITLE
feat:add interface to get support webhook map

### DIFF
--- a/.github/workflows/knative-boilerplate.yaml
+++ b/.github/workflows/knative-boilerplate.yaml
@@ -42,10 +42,10 @@ jobs:
 
     steps:
 
-      - name: Set up Go 1.16.x
+      - name: Set up Go 1.17.x
         uses: actions/setup-go@v2
         with:
-          go-version: 1.16.x
+          go-version: 1.17.x
         id: go
 
       - name: Check out code

--- a/.github/workflows/knative-go-build.yaml
+++ b/.github/workflows/knative-go-build.yaml
@@ -27,7 +27,7 @@ jobs:
     name: Build
     strategy:
       matrix:
-        go-version: [1.16.x]
+        go-version: [1.17.x]
         platform: [ubuntu-latest]
 
     runs-on: ${{ matrix.platform }}

--- a/.github/workflows/knative-go-test.yaml
+++ b/.github/workflows/knative-go-test.yaml
@@ -31,7 +31,7 @@ jobs:
     name: Unit Tests
     strategy:
       matrix:
-        go-version: [1.16.x]
+        go-version: [1.17.x]
         platform: [ubuntu-latest]
 
     runs-on: ${{ matrix.platform }}

--- a/.github/workflows/knative-release-notes.yaml
+++ b/.github/workflows/knative-release-notes.yaml
@@ -41,7 +41,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.16.x
+          go-version: 1.17.x
 
       - name: Install Dependencies
         run: GO111MODULE=on go get k8s.io/release/cmd/release-notes

--- a/.github/workflows/knative-style.yaml
+++ b/.github/workflows/knative-style.yaml
@@ -40,10 +40,10 @@ jobs:
           importpath: golang.org/x/tools/cmd/goimports
 
     steps:
-      - name: Set up Go 1.16.x
+      - name: Set up Go 1.17.x
         uses: actions/setup-go@v2
         with:
-          go-version: 1.16.x
+          go-version: 1.17.x
         id: go
 
       - name: Check out code
@@ -89,10 +89,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Set up Go 1.16.x
+      - name: Set up Go 1.17.x
         uses: actions/setup-go@v2
         with:
-          go-version: 1.16.x
+          go-version: 1.17.x
         id: go
 
       - name: Check out code
@@ -169,7 +169,7 @@ jobs:
           echo '::group:: Flagging trailing whitespace with reviewdog 🐶 ...'
           # Don't fail because of grep
           set +o pipefail
-          
+
           # Exclude generated and vendored files, plus some legacy
           # paths until we update all .gitattributes
           git ls-files |

--- a/.github/workflows/nostackdriver.yaml
+++ b/.github/workflows/nostackdriver.yaml
@@ -25,10 +25,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Set up Go 1.16.x
+      - name: Set up Go 1.17.x
         uses: actions/setup-go@v2
         with:
-          go-version: 1.16.x
+          go-version: 1.17.x
 
       - name: Check out code
         uses: actions/checkout@v2

--- a/apis/meta/v1alpha1/cloudevent.go
+++ b/apis/meta/v1alpha1/cloudevent.go
@@ -88,6 +88,7 @@ const (
 	CloudEventExtSender            = "sender"
 	CloudEventExtPullRequestNumber = "number"
 	CloudEventExtCodeRepository    = "repository"
+	CloudEventExtWebhookType       = "webhooktype"
 
 	// Triggered when a pull request's head branch is updated.
 	// For example, when the head branch is updated from the base branch, when new commits are pushed to the head branch, or when the base branch is changed.

--- a/apis/meta/v1alpha1/webhook_types.go
+++ b/apis/meta/v1alpha1/webhook_types.go
@@ -20,6 +20,31 @@ import (
 	"knative.dev/pkg/apis"
 )
 
+// WebhookEventSupportType consists of event type and "Event"
+type WebhookEventSupportType string
+
+func (w WebhookEventSupportType) String() string {
+	return string(w)
+}
+
+const (
+	// https://github.com/katanomi/spec/pull/80
+	// key in integrationClass.status
+	// CodeRepositoryPushWebhookEvent event value for code repository's push webhook
+	CodeRepositoryPushWebhookEvent WebhookEventSupportType = "CodeRepositoryPushEvent"
+	// CodeRepositoryTagWebhookEvent event values for code repository's tag webhook
+	CodeRepositoryTagWebhookEvent WebhookEventSupportType = "CodeRepositoryTagEvent"
+	// CodeRepositoryPullRequestWebhookEvent event values for code repository's pr webhook
+	CodeRepositoryPullRequestWebhookEvent WebhookEventSupportType = "CodeRepositoryPullRequestEvent"
+	// ArtifactDeleteWebhookEvent event values for artifact's delete webhook
+	ArtifactDeleteWebhookEvent WebhookEventSupportType = "ArtifactDeleteEvent"
+	// ArtifactPushWebhookEvent event values for artifact's push webhook
+	ArtifactPushWebhookEvent WebhookEventSupportType = "ArtifactPushEvent"
+
+	// WebhookEventSuffix key's suffix in integrationClass.status
+	WebhookEventSuffix = "Event"
+)
+
 // WebhookRegisterSpec specifications to register a webhook
 type WebhookRegisterSpec struct {
 	// URI stores the Uniform Resource Identifier for webhook resource

--- a/examples/sample-e2e/another/another.go
+++ b/examples/sample-e2e/another/another.go
@@ -1,3 +1,4 @@
+//go:build e2e
 // +build e2e
 
 /*

--- a/examples/sample-e2e/e2e_test.go
+++ b/examples/sample-e2e/e2e_test.go
@@ -1,3 +1,4 @@
+//go:build e2e
 // +build e2e
 
 /*

--- a/examples/sample-e2e/testcase_test.go
+++ b/examples/sample-e2e/testcase_test.go
@@ -1,3 +1,4 @@
+//go:build e2e
 // +build e2e
 
 /*

--- a/plugin/client/interface.go
+++ b/plugin/client/interface.go
@@ -57,6 +57,11 @@ type PluginRegister interface {
 	GetAllowEmptySecret() []string
 }
 
+type AdditionalWebhookRegister interface {
+	// GetWebhookSupport get webhook support map
+	GetWebhookSupport() map[metav1alpha1.WebhookEventSupportType][]string
+}
+
 // AuthCheck implements an authorization check method for plugins
 type AuthChecker interface {
 	AuthCheck(ctx context.Context, option metav1alpha1.AuthCheckOptions) (*metav1alpha1.AuthCheck, error)


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

add interface GetWebhookSupport to support plugin register webhookType to integrationClass

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [√] [`spec` feat/add-webhook-support-interface](https://github.com/katanomi/spec/pull/80) included
- [√] Follows the [commit message standard](https://github.com/katanomi/spec/blob/main/CONTRIBUTING.md#commits)
- [√] Meets the [contributing guidelines](https://github.com/katanomi/spec/blob/main/CONTRIBUTING.md) (including
  functionality, content, code)
- [√] Test cases with documentation and functionality works as expected using current and related github repos (MUST deploy and check)
- [√] Release notes block below has been filled in or deleted (only if no user facing changes)

# Release Notes

API changes
Any changes in behavior

```release-note
Register webhook support map into integrationClass by implementing the GetWebhookSupport function
```
