### PR TITLE
feat:add function for plugin method unsupport

### DIFF
--- a/plugin/route/plugin.go
+++ b/plugin/route/plugin.go
@@ -1,0 +1,69 @@
+/*
+Copyright 2021 The Katanomi Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package route
+
+import (
+	"net/http"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/emicklei/go-restful/v3"
+	kerrors "github.com/katanomi/pkg/errors"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+type pluginMethodUnsupport struct {
+	tags []string
+}
+
+// NewPluginMethodUnsupport return an error with plugin client
+func NewPluginMethodUnsupport() Route {
+	return &pluginMethodUnsupport{
+		tags: []string{"plugin"},
+	}
+}
+
+// Register route
+func (a *pluginMethodUnsupport) Register(ws *restful.WebService) {
+	ws.Route(
+		ws.POST("/{anything:*}").To(a.PluginMethodSupportError),
+	)
+	ws.Route(
+		ws.DELETE("/{anything:*}").To(a.PluginMethodSupportError),
+	)
+	ws.Route(
+		ws.GET("/{anything:*}").To(a.PluginMethodSupportError),
+	)
+	ws.Route(
+		ws.PATCH("/{anything:*}").To(a.PluginMethodSupportError),
+	)
+}
+
+func (a *pluginMethodUnsupport) PluginMethodSupportError(request *restful.Request, response *restful.Response) {
+	err := errors.NewGenericServerResponse(
+		http.StatusNotImplemented,
+		request.Request.Method,
+		schema.GroupResource{},
+		request.Request.URL.String(),
+		"The plugin has not implemented this function yet",
+		0,
+		false,
+	)
+	err.ErrStatus.Reason = metav1.StatusReasonMethodNotAllowed
+	kerrors.HandleError(request, response, err)
+}

--- a/plugin/route/route.go
+++ b/plugin/route/route.go
@@ -48,6 +48,13 @@ type Route interface {
 func match(c client.Interface) []Route {
 	routes := make([]Route, 0)
 
+	defer func() {
+		// if routes length is 0, NewService will return an error.
+		if len(routes) != 0 {
+			routes = append(routes, NewPluginMethodUnsupport())
+		}
+	}()
+
 	if v, ok := c.(client.ProjectLister); ok {
 		routes = append(routes, NewProjectList(v))
 	}


### PR DESCRIPTION
# Changes

add route for plugin method unsupport

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] [feat/add-func-plugin-unspport](https://github.com/katanomi/spec/tree/feat/add-func-plugin-unspport) included
- [x] Follows the [commit message standard](https://github.com/katanomi/spec/blob/main/CONTRIBUTING.md#commits)
- [x] Meets the [contributing guidelines](https://github.com/katanomi/spec/blob/main/CONTRIBUTING.md) (including
  functionality, content, code)
- [x] Test cases with documentation and functionality works as expected using current and related github repos (MUST deploy and check)
- [x] Release notes block below has been filled in or deleted (only if no user facing changes)

# Release Notes

- API changes

For pull requests with a release note:

```release-note
add route for plugin method unsupport
```
