### PR TITLE
feat:set status for list commitstatus when one commit failed

### DIFF
--- a/apis/meta/v1alpha1/gitcommitstatus_types.go
+++ b/apis/meta/v1alpha1/gitcommitstatus_types.go
@@ -57,13 +57,20 @@ type GitCommitStatusInfo struct {
 	Properties *runtime.RawExtension `json:"properties,omitempty"`
 }
 
+type GitCommitStatusInfoList []GitCommitStatusInfo
+
+type GitCommitStatusStatus struct {
+	GitCommitStatusInfoList
+	*apis.Condition
+}
+
 // GitCommitStatus object for plugin
 type GitCommitStatus struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
 	Spec   GitCommitStatusSpec   `json:"spec"`
-	Status []GitCommitStatusInfo `json:"status"`
+	Status GitCommitStatusStatus `json:"status"`
 }
 
 type GitCommitStatusSpec struct {


### PR DESCRIPTION
# Changes

feat:set status for list commitstatus when one commit failed

# Submitter Checklist

- [x] [feat/set-status-for-parallel-list](https://github.com/katanomi/spec/pull/96) included
- [x] Follows the [commit message standard](https://github.com/katanomi/spec/blob/main/CONTRIBUTING.md#commits)
- [x] Meets the [contributing guidelines](https://github.com/katanomi/spec/blob/main/CONTRIBUTING.md) (including
  functionality, content, code)
- [x] Test cases with documentation and functionality works as expected using current and related github repos (MUST deploy and check)
- [x] Release notes block below has been filled in or deleted (only if no user facing changes)

# Release Notes

API changes

```release-note
set status for list commitstatus when one commit failed
```