### PR TITLE
feat: add trigger name annotation key

### DIFF
--- a/apis/meta/v1alpha1/labels_annotations.go
+++ b/apis/meta/v1alpha1/labels_annotations.go
@@ -62,8 +62,10 @@ const (
 	UpdatedByAnnotationKey = "katanomi.dev/updatedBy"
 	// SecretTypeAnnotationKey annotation key for an existed secret with a different type
 	SecretTypeAnnotationKey = "katanomi.dev/secretType" //nolint:gosec
-	//ClusterNameAnnotationKey annotation key to store resource cluster name
+	// ClusterNameAnnotationKey annotation key to store resource cluster name
 	ClusterNameAnnotationKey = "integrations.katanomi.dev/clusterName"
+	// TriggerNameAnnotationKey annotation key to store a friendly trigger name
+	TriggerNameAnnotationKey = "katanomi.dev/triggerName"
 )
 
 // Attribute keys for Integrations

--- a/apis/meta/v1alpha1/triggeredby_types.go
+++ b/apis/meta/v1alpha1/triggeredby_types.go
@@ -72,7 +72,7 @@ func (by TriggeredBy) IsZero() bool {
 	return by.User == nil &&
 		by.CloudEvent == nil &&
 		by.Ref == nil &&
-		by.TriggeredTimestamp == nil &&
+		by.TriggeredTimestamp.IsZero() &&
 		by.TriggeredType.String() == ""
 }
 

--- a/apis/meta/v1alpha1/triggeredby_types_test.go
+++ b/apis/meta/v1alpha1/triggeredby_types_test.go
@@ -64,6 +64,19 @@ func TestFromAnnotation(t *testing.T) {
 		g.Expect(by.Ref.Kind).Should(BeEquivalentTo("Trigger"))
 	})
 
+	t.Run("annotations has triggeredby key with user and triggeredTimestamp", func(t *testing.T) {
+		g := NewGomegaWithT(t)
+
+		annotations := map[string]string{
+			TriggeredByAnnotationKey: `{"user":{"kind":"User","name":"admin"},"triggeredTimestamp":"2022-02-09T05:34:22Z"}`,
+		}
+		by, err := (&TriggeredBy{}).FromAnnotation(annotations)
+		g.Expect(err).Should(BeNil())
+		g.Expect(by).ShouldNot(BeNil())
+		g.Expect(by.User.Name).Should(BeEquivalentTo("admin"))
+		g.Expect(by.TriggeredTimestamp).ShouldNot(BeNil())
+	})
+
 	t.Run("by is nil", func(t *testing.T) {
 		g := NewGomegaWithT(t)
 

--- a/webhook/admission/transform.go
+++ b/webhook/admission/transform.go
@@ -58,8 +58,12 @@ func WithTriggeredBy() TransformFunc {
 		if triggeredBy.User == nil || triggeredBy.User.Name == "" {
 			triggeredBy.User = SubjectFromRequest(req)
 		}
-		if triggeredBy.TriggeredTimestamp == nil {
+		if triggeredBy.TriggeredTimestamp.IsZero() {
 			creation := metaobj.GetCreationTimestamp()
+			// if creation is not set, we set it to the current time.
+			if creation.IsZero() {
+				creation = metav1.Now()
+			}
 			triggeredBy.TriggeredTimestamp = &creation
 		}
 		annotations, err = triggeredBy.SetIntoAnnotation(annotations)


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

* add annotation key`katanomi.dev/triggerName` to store the friendly name of the trigger.
* correction trigger timestamp
  * if the creationTimestamp is not set, we use to the current time.

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [X] [`spec` PR link](https://github.com/katanomi/spec) included
  - https://github.com/katanomi/spec/pull/98
- [X] Follows the [commit message standard](https://github.com/katanomi/spec/blob/main/CONTRIBUTING.md#commits)
- [X] Meets the [contributing guidelines](https://github.com/katanomi/spec/blob/main/CONTRIBUTING.md) (including
  functionality, content, code)
- [ ] Test cases with documentation and functionality works as expected using current and related github repos (MUST deploy and check)
- [X] Release notes block below has been filled in or deleted (only if no user facing changes)
