### PR TITLE
add generic resource name validation

### DIFF
--- a/apis/validation/name_validation.go
+++ b/apis/validation/name_validation.go
@@ -31,6 +31,11 @@ const DNS1123UnderscoreLabelMaxLength int = validation.DNS1123LabelMaxLength
 
 var dns1123LabelRegexp = regexp.MustCompile("^" + dns1123UnderscoreLabelFmt + "$")
 
+const genericResourceNameFmt string = "[-./A-Za-z0-9_]+"
+const genericResourceNameErrMsg string = "a resource name must consist of lower case alphanumeric characters, '_' or '-' or '/' or '.' "
+
+var genericResourceNameRegexp = regexp.MustCompile("^" + genericResourceNameFmt + "$")
+
 // IsDNS1123UnderscoreLabel tests for a string that conforms to the definition of a label in
 // DNS (RFC 1123) but accepting underscores in the middle.
 func IsDNS1123UnderscoreLabel(value string) []string {
@@ -44,11 +49,31 @@ func IsDNS1123UnderscoreLabel(value string) []string {
 	return errs
 }
 
+func IsGenericResourceName(value string) []string {
+	var errs []string
+
+	if !genericResourceNameRegexp.MatchString(value) {
+		errs = append(errs, validation.RegexError(genericResourceNameErrMsg, genericResourceNameFmt, "my-name", "abc/123"))
+	}
+	return errs
+}
+
 // ValidateItemNameUnderscore validates a name of an item in a slice. this is used in
 // resources,  volumes and etc
 func ValidateItemNameUnderscore(name string, fld *field.Path) field.ErrorList {
 	errs := field.ErrorList{}
 	errList := IsDNS1123UnderscoreLabel(name)
+	if len(errList) > 0 {
+		for _, errStr := range errList {
+			errs = append(errs, field.Invalid(fld, name, errStr))
+		}
+	}
+	return errs
+}
+
+func ValidateGenericResourceName(name string, fld *field.Path) field.ErrorList {
+	errs := field.ErrorList{}
+	errList := IsGenericResourceName(name)
 	if len(errList) > 0 {
 		for _, errStr := range errList {
 			errs = append(errs, field.Invalid(fld, name, errStr))

--- a/apis/validation/nameset_test.go
+++ b/apis/validation/nameset_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package validation
 
 import (
+	"fmt"
 	"testing"
 
 	. "github.com/onsi/gomega"
@@ -55,6 +56,89 @@ func TestValidateDuplicatedName(t *testing.T) {
 		t.Run(i, func(t *testing.T) {
 			g := NewGomegaWithT(t)
 			errs := ValidateDuplicatedName(test.FieldPath, test.Name, test.Set)
+			test.Evaluation(g, errs)
+		})
+	}
+
+}
+
+func TestValidateGenericResourceName(t *testing.T) {
+	// g := NewGomegaWithT(t)
+	table := []struct {
+		Name       string
+		FieldPath  *field.Path
+		Evaluation func(g *WithT, errs field.ErrorList)
+	}{
+
+		{
+			"",
+			field.NewPath("a"),
+			func(g *WithT, errs field.ErrorList) {
+				g.Expect(errs).To(HaveLen(1))
+			},
+		},
+		{
+			"abc",
+			field.NewPath("abc"),
+			func(g *WithT, errs field.ErrorList) {
+				g.Expect(errs).To(HaveLen(0))
+			},
+		},
+		{
+			"abc-def",
+			field.NewPath("def"),
+			func(g *WithT, errs field.ErrorList) {
+				g.Expect(errs).To(HaveLen(0))
+			},
+		},
+		{
+			"abc-def/gh",
+			field.NewPath("gh"),
+			func(g *WithT, errs field.ErrorList) {
+				g.Expect(errs).To(HaveLen(0))
+			},
+		},
+		{
+			"abc-def/g-h",
+			field.NewPath("g-h"),
+			func(g *WithT, errs field.ErrorList) {
+				g.Expect(errs).To(HaveLen(0))
+			},
+		},
+		{
+			"abc-def/g-h_i",
+			field.NewPath("ghi"),
+			func(g *WithT, errs field.ErrorList) {
+				g.Expect(errs).To(HaveLen(0))
+			},
+		},
+		{
+			"abc-def/g-h_i.j",
+			field.NewPath("j"),
+			func(g *WithT, errs field.ErrorList) {
+				g.Expect(errs).To(HaveLen(0))
+			},
+		},
+		{
+			"Abc-def/g-h_i.j",
+			field.NewPath("j2"),
+			func(g *WithT, errs field.ErrorList) {
+				g.Expect(errs).To(HaveLen(0))
+			},
+		},
+		{
+			"Abc-def/g-h_i:j",
+			field.NewPath("j3"),
+			func(g *WithT, errs field.ErrorList) {
+				g.Expect(errs).To(HaveLen(1))
+			},
+		},
+	}
+
+	for i, test := range table {
+		t.Run(fmt.Sprintf("case %d", i), func(t *testing.T) {
+			g := NewGomegaWithT(t)
+			errs := ValidateGenericResourceName(test.Name, test.FieldPath)
 			test.Evaluation(g, errs)
 		})
 	}


### PR DESCRIPTION
Signed-off-by: jtcheng <jtcheng@alauda.io>

# Changes

add generic resource name validation, allow all strings that match ^[-./A-Za-z0-9_]+$

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [`spec` PR link](https://github.com/katanomi/spec) included
- [x] Follows the [commit message standard](https://github.com/katanomi/spec/blob/main/CONTRIBUTING.md#commits)
- [x] Meets the [contributing guidelines](https://github.com/katanomi/spec/blob/main/CONTRIBUTING.md) (including
  functionality, content, code)
- [x] Test cases with documentation and functionality works as expected using current and related github repos (MUST deploy and check)
- [x] Release notes block below has been filled in or deleted (only if no user facing changes)

# Release Notes
```release-note
NONE
```