### PR TITLE
feat: add conversion feature to convert userinfo into subject

### DIFF
--- a/user/matching/matchuser.go
+++ b/user/matching/matchuser.go
@@ -60,3 +60,19 @@ func IsRightUser(userInfo authenticationv1.UserInfo, subject rbacv1.Subject) boo
 	}
 	return userMatch(userInfo, subjects)
 }
+
+func ConvertUserInfoToSubject(userInfo authenticationv1.UserInfo, namespace string) (subject rbacv1.Subject) {
+	isServiceAccount := strings.HasPrefix(userInfo.Username, serviceaccount.ServiceAccountUsernamePrefix)
+	if isServiceAccount {
+		return rbacv1.Subject{
+			Kind:      rbacv1.ServiceAccountKind,
+			Name:      strings.TrimPrefix(userInfo.Username, serviceaccount.ServiceAccountUsernamePrefix),
+			Namespace: namespace,
+		}
+	}
+
+	return rbacv1.Subject{
+		Kind: rbacv1.UserKind,
+		Name: userInfo.Username,
+	}
+}

--- a/user/matching/matchuser_test.go
+++ b/user/matching/matchuser_test.go
@@ -95,3 +95,42 @@ var _ = Describe("Match test", func() {
 		Entry("service account name is found because of different namespace", serviceAccountConfigWildcard, "foo", "foo", BeFalse()),
 	)
 })
+
+var _ = Describe("Convert test", func() {
+	var (
+		defaultNamespace = "default"
+		userInfo         authenticationv1.UserInfo
+		subject          rbacv1.Subject
+	)
+
+	JustBeforeEach(func() {
+		subject = ConvertUserInfoToSubject(userInfo, defaultNamespace)
+	})
+
+	When("kind is user", func() {
+		BeforeEach(func() {
+			userInfo.Username = "user"
+		})
+		It("should convert to user", func() {
+			expectUser := rbacv1.Subject{
+				Kind: rbacv1.UserKind,
+				Name: "user",
+			}
+			Expect(subject).To(Equal(expectUser))
+		})
+	})
+
+	When("kind is sa", func() {
+		BeforeEach(func() {
+			userInfo.Username = "system:serviceaccount:default"
+		})
+		It("should convert to sa", func() {
+			expectSa := rbacv1.Subject{
+				Kind:      rbacv1.ServiceAccountKind,
+				Name:      "default",
+				Namespace: defaultNamespace,
+			}
+			Expect(subject).To(Equal(expectSa))
+		})
+	})
+})


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes
* add conversion feature to convert userinfo into subject

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [`spec` PR link](https://github.com/katanomi/spec) included
- [X] Follows the [commit message standard](https://github.com/katanomi/spec/blob/main/CONTRIBUTING.md#commits)
- [X] Meets the [contributing guidelines](https://github.com/katanomi/spec/blob/main/CONTRIBUTING.md) (including
  functionality, content, code)
- [X] Test cases with documentation and functionality works as expected using current and related github repos (MUST deploy and check)
- [X] Release notes block below has been filled in or deleted (only if no user facing changes)
