### PR TITLE
feat: lazy load logging setup

### DIFF
--- a/logging/setup.go
+++ b/logging/setup.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 The Katanomi Authors.
+Copyright 2022 The Katanomi Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -17,18 +17,22 @@ limitations under the License.
 package logging
 
 import (
+	"sync"
+
 	"go.uber.org/zap"
 	"knative.dev/pkg/logging"
 )
 
-var setupLogger *zap.SugaredLogger
-
-func init() {
-	setupLogger, _ = logging.NewLogger(setupLogConfig, "debug")
-}
+var (
+	setupLogger *zap.SugaredLogger
+	once        sync.Once
+)
 
 // SetupLogger should only be used as a fallback for a logger when
 func SetupLogger(name string) *zap.SugaredLogger {
+	once.Do(func() {
+		setupLogger, _ = logging.NewLogger(setupLogConfig, "debug")
+	})
 	return setupLogger.Named(name)
 }
 


### PR DESCRIPTION
延迟初始化日志库的加载。

目前只要间接导入了该包，比如会出现几个日志：
```
2022-03-18T22:48:15.019+0800	info	logging/config.go:116	Successfully created the logger.
2022-03-18T22:48:15.019+0800	info	logging/config.go:117	Logging level set to: debug
2022-03-18T22:48:15.019+0800	info	logging/config.go:79	Fetch GitHub commit ID from kodata failed	{"error": "\"KO_DATA_PATH\" does not exist or is empty"}
```

目前的`SetupLogger`函数还没有在其他地方被真的使用。理论上这个文件不存在，也不会对其他功能产生影响。

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes
* lazy load logging setup

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [`spec` PR link](https://github.com/katanomi/spec) included
- [X] Follows the [commit message standard](https://github.com/katanomi/spec/blob/main/CONTRIBUTING.md#commits)
- [X] Meets the [contributing guidelines](https://github.com/katanomi/spec/blob/main/CONTRIBUTING.md) (including
  functionality, content, code)
- [ ] Test cases with documentation and functionality works as expected using current and related github repos (MUST deploy and check)
- [X] Release notes block below has been filled in or deleted (only if no user facing changes)
