### PR TITLE
fix the bugs that cannot report client-go metrics

### DIFF
--- a/sharedmain/app.go
+++ b/sharedmain/app.go
@@ -30,6 +30,9 @@ import (
 	"time"
 
 	utilyaml "k8s.io/apimachinery/pkg/util/yaml"
+	// load sigs.k8s.io/controller-runtime@v0.8.3/pkg/metrics/workqueue.go:99  workqueue.SetProvider(workqueueMetricsProvider{}) firstly
+	// avoid knative-pkg@v0.0.0-20220128061436-ff5a1e531de2/controller/stats_reporter.go:95 loading  firstly
+	_ "sigs.k8s.io/controller-runtime/pkg/metrics"
 
 	"k8s.io/client-go/dynamic"
 


### PR DESCRIPTION
import sigs.k8s.io/controller-runtime/pkg/metrics to avoid invoking workqueue.SetProvider by knative-pkg@v0.0.0-20220128061436-ff5a1e531de2/controller/stats_reporter.go:95

https://github.com/katanomi/knative-pkg/blob/ff5a1e531de2b2eeb63d2e8b9c975d1ced840625/controller/stats_reporter.go#L95 will override 
[sigs.k8s.io/controller-runtime@v0.8.3/pkg/metrics/workqueue.go:99](https://github.com/kubernetes-sigs/controller-runtime/blob/v0.8.3/pkg/metrics/workqueue.go#L99)  that caused cannot report client-go metrics correctly.
we should ensure doing `init` of controller-runtime firstly 



Signed-off-by: jtcheng <jtcheng@alauda.io>


# Changes

fix the bugs that cannot report client-go metrics

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [`spec` PR link](https://github.com/katanomi/spec) included
- [x] Follows the [commit message standard](https://github.com/katanomi/spec/blob/main/CONTRIBUTING.md#commits)
- [x] Meets the [contributing guidelines](https://github.com/katanomi/spec/blob/main/CONTRIBUTING.md) (including
  functionality, content, code)
- [x] Test cases with documentation and functionality works as expected using current and related github repos (MUST deploy and check)
- [x] Release notes block below has been filled in or deleted (only if no user facing changes)

# Release Notes

For pull requests with a release note:

```release-note
Bug Fix: fix the bug that cannot report client-go metrics
```
