### PR TITLE
feat:add func for get value in ListOptions.Search

### DIFF
--- a/apis/meta/v1alpha1/listmeta_tyes_test.go
+++ b/apis/meta/v1alpha1/listmeta_tyes_test.go
@@ -1,0 +1,44 @@
+/*
+Copyright 2022 The Katanomi Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha1
+
+import (
+	"testing"
+)
+
+func TestGetSearchValue(t *testing.T) {
+	opt := ListOptions{
+		Search: map[string][]string{SearchValueKey: {"test", "test2"}},
+	}
+	value := opt.GetSearchFirstElement(SearchValueKey)
+	if value != "test" {
+		t.Fail()
+		return
+	}
+	opt.Search = map[string][]string{SearchValueKey: {}}
+	value = opt.GetSearchFirstElement(SearchValueKey)
+	if value != "" {
+		t.Fail()
+		return
+	}
+	opt.Search = map[string][]string{}
+	value = opt.GetSearchFirstElement(SearchValueKey)
+	if value != "" {
+		t.Fail()
+		return
+	}
+}

--- a/apis/meta/v1alpha1/listmeta_types.go
+++ b/apis/meta/v1alpha1/listmeta_types.go
@@ -26,6 +26,9 @@ const (
 	NameSortKey        SortBy = "name"
 	UpdatedTimeSortKey SortBy = "updatedTime"
 	CreatedTimeSortKey SortBy = "createdTime"
+
+	// SearchValueKey The key of the keyword used for the search
+	SearchValueKey = "searchValue"
 )
 
 type SortOrder string
@@ -75,6 +78,16 @@ type ListOptions struct {
 
 	// Sort for listing
 	Sort []SortOptions `json:"sort"`
+}
+
+// GetSearchFirstElement get first element by key that in search map
+func (opt ListOptions) GetSearchFirstElement(key string) (value string) {
+	if valueList, ok := opt.Search[key]; ok {
+		if len(valueList) != 0 {
+			value = valueList[0]
+		}
+	}
+	return
 }
 
 // SortOptions options for sort


### PR DESCRIPTION
# Changes

Add a method to get the first element of a key in Listoption.Search

# Submitter Checklist

- [ ] [`spec` PR link](https://github.com/katanomi/spec) included
- [x] Follows the [commit message standard](https://github.com/katanomi/spec/blob/main/CONTRIBUTING.md#commits)
- [x] Meets the [contributing guidelines](https://github.com/katanomi/spec/blob/main/CONTRIBUTING.md) (including
  functionality, content, code)
- [x] Test cases with documentation and functionality works as expected using current and related github repos (MUST deploy and check)
- [x] Release notes block below has been filled in or deleted (only if no user facing changes)

# Release Notes

- Any changes in behavior

```release-note
Add a method to get the first element of a key in Listoption.Search
```
