### PR TITLE
wrapping transport once

### DIFF
--- a/tracing/transport.go
+++ b/tracing/transport.go
@@ -62,6 +62,9 @@ func WrapTransport(rt http.RoundTripper) http.RoundTripper {
 	if rt == nil {
 		rt = http.DefaultTransport
 	}
+	if _, ok := rt.(*Transport); ok {
+		return rt
+	}
 	return &Transport{
 		originalRT: rt,
 		Transport: otelhttp.NewTransport(rt,

--- a/tracing/transport_test.go
+++ b/tracing/transport_test.go
@@ -43,12 +43,29 @@ var _ = Describe("testing for WrapTransport", func() {
 		})
 	})
 	Context("when special transport is provided", func() {
-		It("should use the special transport", func() {
-			originalTp := &http.Transport{}
-			rt := WrapTransport(originalTp)
-			tp, ok := rt.(*Transport)
-			Expect(ok).Should(BeTrue())
-			Expect(tp.originalRT).Should(Equal(originalTp))
+		var (
+			originalTp *http.Transport
+			rt         http.RoundTripper
+		)
+		BeforeEach(func() {
+			originalTp = &http.Transport{}
+			rt = WrapTransport(originalTp)
+		})
+		When("wrapping once", func() {
+			It("should use the special transport", func() {
+				tp, ok := rt.(*Transport)
+				Expect(ok).Should(BeTrue())
+				Expect(tp.originalRT).Should(Equal(originalTp))
+			})
+		})
+		When("wrapping multiple times", func() {
+			It("should wrap only once", func() {
+				rt2 := WrapTransport(rt)
+				tp2, ok := rt2.(*Transport)
+				Expect(ok).Should(BeTrue())
+				Expect(tp2.originalRT).Should(Equal(originalTp))
+				Expect(tp2.originalRT).ShouldNot(Equal(rt))
+			})
 		})
 	})
 	Context("when handler request", func() {


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes
When wrapping transport multiple times, it only takes effect once

<img width="799" alt="image" src="https://user-images.githubusercontent.com/18688410/171355963-f83159af-7254-47fa-82f8-a58f6b7eba8d.png">

<!--
Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)!

-->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] [`spec` PR link](https://github.com/katanomi/spec) included
- [x] Follows the [commit message standard](https://github.com/katanomi/spec/blob/main/CONTRIBUTING.md#commits)
- [x] Meets the [contributing guidelines](https://github.com/katanomi/spec/blob/main/CONTRIBUTING.md) (including
  functionality, content, code)
- [x] Test cases with documentation and functionality works as expected using current and related github repos (MUST deploy and check)
- [x] Release notes block below has been filled in or deleted (only if no user facing changes)

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->