### PR TITLE
feat: add method for multicluster

### DIFF
--- a/multicluster/clusterregistry_client.go
+++ b/multicluster/clusterregistry_client.go
@@ -194,6 +194,14 @@ func (m *ClusterRegistryClient) GetConfigFromCluster(ctx context.Context, cluste
 	return
 }
 
-func (m *ClusterRegistryClient) ListClustersNamespaces(ctx context.Context, namespace string) (clusterNamespaces map[*corev1.ObjectReference][]corev1.Namespace, err error) {
+// ListClustersNamespaces returns the project namespaces in the clusters
+func (m *ClusterRegistryClient) ListClustersNamespaces(ctx context.Context,
+	namespace string) (clusterNamespaces map[*corev1.ObjectReference][]corev1.Namespace, err error) {
 	return map[*corev1.ObjectReference][]corev1.Namespace{}, err
+}
+
+// IsNamespaceInProject returns true if the namespace is in the project
+func (m *ClusterRegistryClient) IsNamespaceInProject(ctx context.Context, projectName string,
+	clusterRef *corev1.ObjectReference, namespace string) (bool, error) {
+	return true, nil
 }

--- a/multicluster/clusterregistry_client_test.go
+++ b/multicluster/clusterregistry_client_test.go
@@ -77,4 +77,18 @@ func TestClusterRegistryClientGetConfig(t *testing.T) {
 		g.Expect(client).ToNot(BeNil())
 	})
 
+	t.Run("list clusters namespaces", func(t *testing.T) {
+		clusterNamespaces, err := clusterClient.ListClustersNamespaces(ctx, "namespace")
+
+		g.Expect(err).To(BeNil())
+		g.Expect(clusterNamespaces).To(HaveLen(0))
+	})
+
+	t.Run("is namespace in this project", func(t *testing.T) {
+		exist, err := clusterClient.IsNamespaceInProject(ctx, "projectName", nil, "namespace")
+
+		g.Expect(err).To(BeNil())
+		g.Expect(exist).To(BeTrue())
+	})
+
 }

--- a/multicluster/interface.go
+++ b/multicluster/interface.go
@@ -39,4 +39,5 @@ type Interface interface {
 
 	// TODO: add this method to the interface and implementation
 	ListClustersNamespaces(ctx context.Context, namespace string) (clusterNamespaces map[*corev1.ObjectReference][]corev1.Namespace, err error)
+	IsNamespaceInProject(ctx context.Context, projectName string, clusterRef *corev1.ObjectReference, namespace string) (bool, error)
 }


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes
* add `IsNamespaceInProject` method for multicluster
  * used to check if a namespace is in the project

<!--
Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)!

-->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [`spec` PR link](https://github.com/katanomi/spec) included
- [X] Follows the [commit message standard](https://github.com/katanomi/spec/blob/main/CONTRIBUTING.md#commits)
- [X] Meets the [contributing guidelines](https://github.com/katanomi/spec/blob/main/CONTRIBUTING.md) (including
  functionality, content, code)
- [X] Test cases with documentation and functionality works as expected using current and related github repos (MUST deploy and check)
- [X] Release notes block below has been filled in or deleted (only if no user facing changes)
