### PR TITLE
feat: Add ResourceTopConditionIsReadyEventually function to help

### DIFF
--- a/testing/conditions.go
+++ b/testing/conditions.go
@@ -57,3 +57,12 @@ func (c *ConditionBuilder) SetReasonMessage(reason, message string, formtKeyValu
 func (c *ConditionBuilder) Done() *apis.Condition {
 	return &c.Condition
 }
+
+// ConditionIsReady returns an error if the condition status is not True
+// useful for Eventually checks
+func ConditionIsReady(condition *apis.Condition) error {
+	if !condition.IsTrue() {
+		return fmt.Errorf("condition type %q value %q != True", condition.Type, condition.Status)
+	}
+	return nil
+}


### PR DESCRIPTION
Integration tests checking if an object's top condition is ready

In most test cases one of the most common tasks is create a resource
and wait for it to be ready before moving on with the needed test logic
this function makes it an out-of-the-box check with custom additional checks

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!--
Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)!

-->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [`spec` PR link](https://github.com/katanomi/spec) included
- [ ] Follows the [commit message standard](https://github.com/katanomi/spec/blob/main/CONTRIBUTING.md#commits)
- [ ] Meets the [contributing guidelines](https://github.com/katanomi/spec/blob/main/CONTRIBUTING.md) (including
  functionality, content, code)
- [ ] Test cases with documentation and functionality works as expected using current and related github repos (MUST deploy and check)
- [ ] Release notes block below has been filled in or deleted (only if no user facing changes)

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->