### PR TITLE
feat: add root command into command/root to be reusable by

### DIFF
--- a/command/args/key_value_test.go
+++ b/command/args/key_value_test.go
@@ -91,7 +91,7 @@ var _ = Describe("GetKeyValues", func() {
 			Expect(result).To(Equal(map[string]string{
 				"this-is-key":         "this-is-value",
 				"this-is-another-key": "this-is-another-value",
-				"key": "with=multiple=equalsigns",
+				"key":                 "with=multiple=equalsigns",
 			}))
 			Expect(ok).To(BeTrue())
 		})

--- a/command/options/doc.go
+++ b/command/options/doc.go
@@ -1,0 +1,18 @@
+/*
+Copyright 2022 The Katanomi Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package options some common options for cli
+package options

--- a/command/options/log.go
+++ b/command/options/log.go
@@ -1,0 +1,60 @@
+/*
+Copyright 2022 The Katanomi Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package options
+
+import (
+	"context"
+
+	"github.com/katanomi/pkg/command/io"
+	"github.com/katanomi/pkg/command/logger"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+)
+
+// Log Log related options
+type Log struct {
+	verbose bool
+	Logger  *zap.SugaredLogger
+}
+
+// Enabled decides whether a given logging level is enabled
+func (opts *Log) Enabled(l zapcore.Level) bool {
+	if opts.verbose {
+		return true
+	}
+
+	return l >= zapcore.InfoLevel
+}
+
+// Setup set up the Log
+func (opts *Log) Setup(ctx context.Context, cmd *cobra.Command, args []string) {
+	if opts.Logger == nil {
+		if l := logger.GetLogger(ctx); l != nil {
+			opts.Logger = l
+		} else {
+			iostreams := io.MustGetIOStreams(ctx)
+			opts.Logger = logger.NewLogger(zapcore.AddSync(iostreams.ErrOut), opts)
+		}
+	}
+}
+
+// AddFlags add flags to options
+func (opts *Log) AddFlags(flags *pflag.FlagSet) {
+	flags.BoolVarP(&opts.verbose, `verbose`, `v`, false, `sets the Log level to be displayed.`)
+}

--- a/command/root/doc.go
+++ b/command/root/doc.go
@@ -1,0 +1,18 @@
+/*
+Copyright 2022 The Katanomi Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package root have reusable root commands for clis
+package root

--- a/command/root/root.go
+++ b/command/root/root.go
@@ -1,0 +1,57 @@
+/*
+Copyright 2022 The Katanomi Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package root
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/katanomi/pkg/command/io"
+	"github.com/katanomi/pkg/command/logger"
+	"github.com/katanomi/pkg/command/options"
+	"github.com/spf13/cobra"
+	"go.uber.org/zap/zapcore"
+)
+
+// SubcommandFunc inits a subcommand to be inserted inside root
+type SubcommandFunc func(ctx context.Context, name string) *cobra.Command
+
+// NewRootCommand initiates all commands. This is the main entrypoint of the cli
+func NewRootCommand(ctx context.Context, name string, subcommands ...SubcommandFunc) *cobra.Command {
+	// sets log as persistent options and provides logger using
+	// context variables
+	logOpts := &options.Log{}
+	streams := io.MustGetIOStreams(ctx)
+	ctx = logger.WithLogger(ctx, logger.NewLogger(zapcore.AddSync(streams.ErrOut), logOpts))
+	rootCmd := &cobra.Command{
+		Use: fmt.Sprintf("%s [command] [options]", name),
+		PersistentPreRun: func(cmd *cobra.Command, args []string) {
+			logOpts.Setup(ctx, cmd, args)
+		},
+		Run: func(cmd *cobra.Command, args []string) {
+			_ = cmd.Help()
+		},
+	}
+	// will persist flag across all subcommands
+	logOpts.AddFlags(rootCmd.PersistentFlags())
+
+	for _, sub := range subcommands {
+		rootCmd.AddCommand(sub(ctx, name))
+	}
+
+	return rootCmd
+}

--- a/command/root/root_suite_test.go
+++ b/command/root/root_suite_test.go
@@ -1,0 +1,85 @@
+/*
+Copyright 2022 The Katanomi Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package root_test
+
+import (
+	// "bytes"
+	"testing"
+
+	"context"
+
+	"github.com/katanomi/pkg/command/io"
+	"github.com/katanomi/pkg/command/root"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/spf13/cobra"
+	clioptions "k8s.io/cli-runtime/pkg/genericclioptions"
+)
+
+func TestRoot(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Root Suite")
+}
+
+var _ = Describe("NewRootCommand", func() {
+	var (
+		ctx         context.Context
+		streams     clioptions.IOStreams
+		cmd         *cobra.Command
+		subcommands []root.SubcommandFunc
+		err         error
+		// out  *bytes.Buffer
+	)
+
+	BeforeEach(func() {
+		streams, _, _, _ = clioptions.NewTestIOStreams()
+		// uses ginkgo writer for logs
+		streams.ErrOut = GinkgoWriter
+		ctx = context.Background()
+		ctx = io.WithIOStreams(ctx, &streams)
+		subcommands = nil
+	})
+
+	JustBeforeEach(func() {
+		cmd = root.NewRootCommand(ctx, "test-cli", subcommands...)
+		err = cmd.Execute()
+
+	})
+	It("cmd is not nil", func() {
+		Expect(cmd).ToNot(BeNil())
+	})
+
+	When("with subcommands", func() {
+		BeforeEach(func() {
+			subcommands = append(subcommands, func(_ context.Context, _ string) *cobra.Command {
+				return &cobra.Command{Use: "subcommamd", Run: func(_ *cobra.Command, _ []string) {}}
+			})
+		})
+		It("should have subcommand", func() {
+			// by default adds completion and help subcommands
+			Expect(cmd.Commands()).To(HaveLen(3), "should have subcommands")
+			Expect(err).To(BeNil(), "should not error")
+		})
+
+	})
+	When("without subcommands", func() {
+		It("should NOT have subcommands", func() {
+			Expect(cmd.Commands()).To(HaveLen(0), "should NOT have subcommands")
+			Expect(err).To(BeNil(), "should not error")
+		})
+	})
+})

--- a/pointer/pointer.go
+++ b/pointer/pointer.go
@@ -32,3 +32,7 @@ func Int64(v int64) *int64 { return &v }
 // String is a helper routine that allocates a new string value
 // to store v and returns a pointer to it.
 func String(v string) *string { return &v }
+
+// Float64 is a helper routine that allocates a new float64 value
+// to store v and returns a pointer to it.
+func Float64(v float64) *float64 { return &v }

--- a/pointer/pointer_test.go
+++ b/pointer/pointer_test.go
@@ -45,3 +45,9 @@ func TestString(t *testing.T) {
 	input := ""
 	g.Expect(String(input)).To(Equal(&input))
 }
+
+func TestFloat64(t *testing.T) {
+	g := NewGomegaWithT(t)
+	input := float64(0)
+	g.Expect(Float64(input)).To(Equal(&input))
+}


### PR DESCRIPTION
other CLI programs

The base root command is simple and can be reused by multiple projects
without having to implement again and again

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

feat: add root command into command/root to be reusable by other CLI programs

The base root command is simple and can be reused by multiple projects
without having to implement again and again

<!--
Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)!

-->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] [`spec` PR link](https://github.com/katanomi/spec) included
- [x] Follows the [commit message standard](https://github.com/katanomi/spec/blob/main/CONTRIBUTING.md#commits)
- [x] Meets the [contributing guidelines](https://github.com/katanomi/spec/blob/main/CONTRIBUTING.md) (including
  functionality, content, code)
- [x] Test cases with documentation and functionality works as expected using current and related github repos (MUST deploy and check)
- [x] Release notes block below has been filled in or deleted (only if no user facing changes)

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->