### PR TITLE
chore: Adds nil treatment for when GitBranch is nil

### DIFF
--- a/apis/meta/v1alpha1/git_branch_funcs.go
+++ b/apis/meta/v1alpha1/git_branch_funcs.go
@@ -23,6 +23,9 @@ import (
 // GetBranchStatus return git branch status
 func (b *GitBranch) GetBranchStatus() (status *BuildGitBranchStatus) {
 	status = &BuildGitBranchStatus{}
+	if b == nil {
+		b = &GitBranch{}
+	}
 	status.Name = b.Name
 	status.Default = false
 	if b.Spec.Default != nil {

--- a/apis/meta/v1alpha1/git_branch_funcs_test.go
+++ b/apis/meta/v1alpha1/git_branch_funcs_test.go
@@ -40,6 +40,18 @@ var _ = Describe("GitBranch.GetBranchStatus", func() {
 	JustBeforeEach(func() {
 		result = branch.GetBranchStatus()
 	})
+	When("struct is nil", func() {
+		BeforeEach(func() {
+			branch = nil
+			LoadYAML("testdata/git_branch_funcs_getbranchstatus.nil.golden.yaml", expected)
+		})
+		It("should return full BuildRunGitStatus", func() {
+			Expect(result).ToNot(BeNil())
+
+			diff := cmp.Diff(result, expected)
+			Expect(diff).To(BeEmpty())
+		})
+	})
 	When("struct has all data", func() {
 		BeforeEach(func() {
 			LoadYAML("testdata/git_branch_funcs_getbranchstatus.full.yaml", branch)

--- a/apis/meta/v1alpha1/testdata/git_branch_funcs_getbranchstatus.nil.golden.yaml
+++ b/apis/meta/v1alpha1/testdata/git_branch_funcs_getbranchstatus.nil.golden.yaml
@@ -1,0 +1,5 @@
+name: ""
+protected: false
+default: false
+webURL: ""
+


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

- chore: Adds nil treatment for when GitBranch is nil
When generating BuildGitBranchStatus now checks and treats GitBranch as nil
and avoid panics in depending code. Some logic inside katanomi/builds was expecting
and testing for nil cases and adding this treatment here improves stability

Unit test was also added

<!--
Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)!

-->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [`spec` PR link](https://github.com/katanomi/spec) included
- [ ] Follows the [commit message standard](https://github.com/katanomi/spec/blob/main/CONTRIBUTING.md#commits)
- [ ] Meets the [contributing guidelines](https://github.com/katanomi/spec/blob/main/CONTRIBUTING.md) (including
  functionality, content, code)
- [ ] Test cases with documentation and functionality works as expected using current and related github repos (MUST deploy and check)
- [ ] Release notes block below has been filled in or deleted (only if no user facing changes)

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->