### PR TITLE
feat: Add IsEmpty methods to AnalysisResult, CodeLintResults and Unit…

### DIFF
--- a/apis/codequality/v1alpha1/code_analysis_funcs.go
+++ b/apis/codequality/v1alpha1/code_analysis_funcs.go
@@ -24,6 +24,15 @@ import (
 	"k8s.io/apimachinery/pkg/util/validation/field"
 )
 
+// IsEmpty returns true if the struct is empty
+func (a AnalysisResult) IsEmpty() bool {
+	attributesEmpty := (a.ProjectID == "" &&
+		a.ReportURL == "" &&
+		a.Result == "" &&
+		a.TaskID == "")
+	return attributesEmpty && a.Metrics.IsEmpty()
+}
+
 // GetObjectWithValues inits an object based on a json.path values map
 // returns nil if values is nil
 func (AnalysisResult) GetObjectWithValues(ctx context.Context, path *field.Path, values map[string]string) (result *AnalysisResult) {
@@ -37,6 +46,14 @@ func (AnalysisResult) GetObjectWithValues(ctx context.Context, path *field.Path,
 		}
 	}
 	return
+}
+
+// IsEmpty returns true if is nil or is empty
+func (a *AnalisysMetrics) IsEmpty() bool {
+	if a == nil {
+		return true
+	}
+	return a.Branch == nil && a.Target == nil && len(a.Ratings) == 0 && len(a.Languages) == 0 && a.CodeSize == nil
 }
 
 // GetObjectWithValues inits an object based on a json.path values map

--- a/apis/codequality/v1alpha1/code_analysis_funcs_test.go
+++ b/apis/codequality/v1alpha1/code_analysis_funcs_test.go
@@ -188,3 +188,33 @@ func TestAnalisysMetricsGetObjectWithValues(t *testing.T) {
 		})
 	}
 }
+
+func TestAnalaysisResultIsEmpty(t *testing.T) {
+	t.Run("is empty struct", func(t *testing.T) {
+		g := gomega.NewGomegaWithT(t)
+		object := AnalysisResult{}
+
+		g.Expect(object.IsEmpty()).To(gomega.BeTrue())
+	})
+
+	t.Run("has metrics but empty", func(t *testing.T) {
+		g := gomega.NewGomegaWithT(t)
+		object := AnalysisResult{Metrics: &AnalisysMetrics{}}
+
+		g.Expect(object.IsEmpty()).To(gomega.BeTrue())
+	})
+
+	t.Run("has any attribute with nil metrics", func(t *testing.T) {
+		g := gomega.NewGomegaWithT(t)
+		object := AnalysisResult{Result: "a"}
+
+		g.Expect(object.IsEmpty()).To(gomega.BeFalse())
+	})
+
+	t.Run("has only metrics", func(t *testing.T) {
+		g := gomega.NewGomegaWithT(t)
+		object := AnalysisResult{Metrics: &AnalisysMetrics{Languages: []string{"a"}}}
+
+		g.Expect(object.IsEmpty()).To(gomega.BeFalse())
+	})
+}

--- a/apis/codequality/v1alpha1/code_lint_funcs.go
+++ b/apis/codequality/v1alpha1/code_lint_funcs.go
@@ -22,6 +22,11 @@ import (
 	"k8s.io/apimachinery/pkg/util/validation/field"
 )
 
+// IsEmpty returns true if the struct is empty
+func (a CodeLintResult) IsEmpty() bool {
+	return a.Result == "" && a.Issues == nil
+}
+
 // GetObjectWithValues inits an object based on a json.path values map
 // returns nil if values is nil
 func (CodeLintResult) GetObjectWithValues(ctx context.Context, path *field.Path, values map[string]string) (result *CodeLintResult) {

--- a/apis/codequality/v1alpha1/code_lint_funcs_test.go
+++ b/apis/codequality/v1alpha1/code_lint_funcs_test.go
@@ -71,3 +71,26 @@ func TestCodeLintResultGetObjectWithValues(t *testing.T) {
 		})
 	}
 }
+
+func TestCodeLintResultIsEmpty(t *testing.T) {
+	t.Run("is empty struct", func(t *testing.T) {
+		g := gomega.NewGomegaWithT(t)
+		object := CodeLintResult{}
+
+		g.Expect(object.IsEmpty()).To(gomega.BeTrue())
+	})
+
+	t.Run("has issues but empty/zero", func(t *testing.T) {
+		g := gomega.NewGomegaWithT(t)
+		object := CodeLintResult{Issues: &CodeLintIssues{}}
+
+		g.Expect(object.IsEmpty()).To(gomega.BeFalse())
+	})
+
+	t.Run("has any attribute with nil issues", func(t *testing.T) {
+		g := gomega.NewGomegaWithT(t)
+		object := CodeLintResult{Result: "a"}
+
+		g.Expect(object.IsEmpty()).To(gomega.BeFalse())
+	})
+}

--- a/apis/codequality/v1alpha1/unit_tests_funcs.go
+++ b/apis/codequality/v1alpha1/unit_tests_funcs.go
@@ -23,6 +23,11 @@ import (
 	"k8s.io/apimachinery/pkg/util/validation/field"
 )
 
+// IsEmpty returns true if the struct is empty
+func (u UnitTestsResult) IsEmpty() bool {
+	return u.Coverage.IsEmpty() && u.TestResult.IsEmpty()
+}
+
 // GetObjectWithValues inits an object based on a json.path values map
 // returns nil if values is nil
 func (UnitTestsResult) GetObjectWithValues(ctx context.Context, path *field.Path, values map[string]string) (result *UnitTestsResult) {
@@ -35,6 +40,14 @@ func (UnitTestsResult) GetObjectWithValues(ctx context.Context, path *field.Path
 	return
 }
 
+// IsEmpty returns true if the struct is empty
+func (c *TestCoverage) IsEmpty() bool {
+	if c == nil {
+		return true
+	}
+	return c.Branches == "" && c.Lines == ""
+}
+
 // GetObjectWithValues inits an object based on a json.path values map
 // returns nil if values is nil
 func (TestCoverage) GetObjectWithValues(ctx context.Context, path *field.Path, values map[string]string) (result *TestCoverage) {
@@ -45,6 +58,14 @@ func (TestCoverage) GetObjectWithValues(ctx context.Context, path *field.Path, v
 		}
 	}
 	return
+}
+
+// IsEmpty returns true if the struct is empty
+func (t *TestResult) IsEmpty() bool {
+	if t == nil {
+		return true
+	}
+	return t.Failed+t.Passed+t.Skipped == 0
 }
 
 // GetObjectWithValues inits an object based on a json.path values map

--- a/apis/codequality/v1alpha1/unit_tests_funcs_test.go
+++ b/apis/codequality/v1alpha1/unit_tests_funcs_test.go
@@ -79,3 +79,40 @@ func TestUnitTestsResultGetObjectWithValues(t *testing.T) {
 		})
 	}
 }
+
+func TestUnitTestsResultIsEmpty(t *testing.T) {
+	t.Run("is empty struct", func(t *testing.T) {
+		g := gomega.NewGomegaWithT(t)
+		object := UnitTestsResult{}
+
+		g.Expect(object.IsEmpty()).To(gomega.BeTrue())
+	})
+
+	t.Run("has non nil coverage but empty", func(t *testing.T) {
+		g := gomega.NewGomegaWithT(t)
+		object := UnitTestsResult{Coverage: &TestCoverage{}}
+
+		g.Expect(object.IsEmpty()).To(gomega.BeTrue())
+	})
+
+	t.Run("has non nil results with empty values nil coverage", func(t *testing.T) {
+		g := gomega.NewGomegaWithT(t)
+		object := UnitTestsResult{TestResult: &TestResult{}}
+
+		g.Expect(object.IsEmpty()).To(gomega.BeTrue())
+	})
+
+	t.Run("has results with nil coverage", func(t *testing.T) {
+		g := gomega.NewGomegaWithT(t)
+		object := UnitTestsResult{TestResult: &TestResult{Passed: 1}}
+
+		g.Expect(object.IsEmpty()).To(gomega.BeFalse())
+	})
+
+	t.Run("nil results with coverage", func(t *testing.T) {
+		g := gomega.NewGomegaWithT(t)
+		object := UnitTestsResult{Coverage: &TestCoverage{Lines: "1"}}
+
+		g.Expect(object.IsEmpty()).To(gomega.BeFalse())
+	})
+}


### PR DESCRIPTION


<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

- feat: Add IsEmpty methods to AnalysisResult, CodeLintResults and UnitTestResults

To avoid storing empty objects, the addition of these methods makes it super simple to verify if the object is empty or not and avoid using unpopulated data

<!--
Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)!

-->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [`spec` PR link](https://github.com/katanomi/spec) included
- [ ] Follows the [commit message standard](https://github.com/katanomi/spec/blob/main/CONTRIBUTING.md#commits)
- [ ] Meets the [contributing guidelines](https://github.com/katanomi/spec/blob/main/CONTRIBUTING.md) (including
  functionality, content, code)
- [ ] Test cases with documentation and functionality works as expected using current and related github repos (MUST deploy and check)
- [ ] Release notes block below has been filled in or deleted (only if no user facing changes)

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->