### PR TITLE
fix: cannot patch stagerun

### DIFF
--- a/apis/meta/v1alpha1/check_validate.go
+++ b/apis/meta/v1alpha1/check_validate.go
@@ -36,7 +36,8 @@ func (r *Check) ValidateChange(ctx context.Context, old *Check, path *field.Path
 		errs = append(errs, field.Forbidden(path, `cannot be unset after creation`))
 	}
 	if r != nil && old == nil {
-		errs = append(errs, field.Forbidden(path, `cannot be set after creation`))
+		// Allow adding fields, the webhook will be check the permissions.
+		// If the check is empty, the controller maybe initialize the check based on the spec information.
 	}
 	if r != nil && old != nil {
 		errs = append(errs, r.Approval.ValidateChange(ctx, old.Approval, path.Child("approval"))...)

--- a/apis/meta/v1alpha1/check_validate_test.go
+++ b/apis/meta/v1alpha1/check_validate_test.go
@@ -92,11 +92,8 @@ var _ = Describe("Test.Check.ValidateChange", func() {
 			old = nil
 		})
 
-		It("should return validation error", func() {
-			Expect(errs).ToNot(BeNil(), "should return an error")
-			// Filter removes items from the ErrorList that match the provided fns.
-			Expect(errs.Filter(field.NewErrorTypeMatcher(field.ErrorTypeForbidden))).To(HaveLen(0))
-			Expect(errs).To(HaveLen(1))
+		It("should NOT return validation error", func() {
+			Expect(errs).To(BeNil(), "should NOT return an error")
 		})
 	})
 

--- a/webhook/admission/approval.go
+++ b/webhook/admission/approval.go
@@ -152,6 +152,11 @@ func (h *approvingHandler) Handle(ctx context.Context, req admission.Request) ad
 
 	oldChecks := h.approval.GetChecks(old)
 	newChecks := h.approval.GetChecks(new)
+	if len(oldChecks) == 0 && len(newChecks) != 0 {
+		// If the old check is empty, maybe the controller is initialized based on the spec information.
+		// In order to pass the validation, the old check is initialized here to be empty.
+		oldChecks = make([]*metav1alpha1.Check, len(newChecks))
+	}
 	oldNewChecksPairs := make([]PairOfOldNewCheck, len(oldChecks))
 	for i := 0; i < len(oldChecks); i++ {
 		oldNewChecksPairs[i] = PairOfOldNewCheck{oldChecks[i], newChecks[i]}

--- a/webhook/admission/approval_validate.go
+++ b/webhook/admission/approval_validate.go
@@ -166,16 +166,17 @@ func (c *checkApproval) Check() (err error) {
 			}
 		}
 		// Approval requires verification of identity, cannot approve on behalf of others.
-		if ((oldUser == nil || oldUser.Input == nil) && newUser.Input != nil) &&
-			!matching.IsRightUser(c.reqUser, newUser.Subject) {
-			err = fmt.Errorf("%q can not approve for user %q", c.reqUser.Username, newUser.Subject.Name)
-			return
-		}
-		// RequiresDifferentApprover if set to true, the user who triggered the StageRun cannot approve, unless an admin
-		if c.approvalSpec.RequiresDifferentApprover &&
-			c.triggeredBy != nil && c.triggeredBy.User != nil && *c.triggeredBy.User == newUser.Subject {
-			err = fmt.Errorf("requiresDifferentApprover is enabled, %q can not approve.", newUser.Subject.Name)
-			return
+		if (oldUser == nil || oldUser.Input == nil) && newUser.Input != nil {
+			if !matching.IsRightUser(c.reqUser, newUser.Subject) {
+				err = fmt.Errorf("%q can not approve for user %q", c.reqUser.Username, newUser.Subject.Name)
+				return
+			}
+			// RequiresDifferentApprover if set to true, the user who triggered the StageRun cannot approve, unless an admin
+			if c.approvalSpec.RequiresDifferentApprover &&
+				c.triggeredBy != nil && c.triggeredBy.User != nil && *c.triggeredBy.User == newUser.Subject {
+				err = fmt.Errorf("requiresDifferentApprover is enabled, %q can not approve.", newUser.Subject.Name)
+				return
+			}
 		}
 	}
 

--- a/webhook/admission/approval_validate.go
+++ b/webhook/admission/approval_validate.go
@@ -39,16 +39,17 @@ type ValidateApprovalFunc func(ctx context.Context, reqUser authenticationv1.Use
 func ValidateApproval(ctx context.Context, reqUser authenticationv1.UserInfo, allowRepresentOthers, isCreateOperation bool,
 	approvalSpecList []*metav1alpha1.ApprovalSpec, checkList []PairOfOldNewCheck, triggeredBy *metav1alpha1.TriggeredBy) (err error) {
 
+	log := logging.FromContext(ctx)
 	defer func() {
 		if err != nil {
-			log := logging.FromContext(ctx)
-			log.Debugw("approval exception detected", "error", err)
+			log.Infow("approval exception detected", "error", err)
 		}
 	}()
 
 	// check needs to be consistent with the number of spec
 	if len(checkList) != len(approvalSpecList) {
 		err = fmt.Errorf("internal error #check != #checkSpec")
+		log.Warnw("validate approval failed", "check", checkList, "checkSpec", approvalSpecList, "error", err)
 		return
 	}
 

--- a/webhook/admission/approval_validate_test.go
+++ b/webhook/admission/approval_validate_test.go
@@ -501,6 +501,17 @@ var _ = Describe("Test.ValidateApproval", func() {
 			})
 		})
 
+		When("cannot to represent others but no changed", func() {
+			BeforeEach(func() {
+				allowRepresentOthers = false
+				new = old
+			})
+
+			It("should NOT return an error", func() {
+				Expect(err).To(BeNil())
+			})
+		})
+
 	})
 
 })


### PR DESCRIPTION
In the scenario where the stagerun is created directly, the controller will initialize the check based on the stage spec information.

This is not common, but it can happen.

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes
* fix: cannot patch stagerun
<!--
Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)!

-->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [`spec` PR link](https://github.com/katanomi/spec) included
- [x] Follows the [commit message standard](https://github.com/katanomi/spec/blob/main/CONTRIBUTING.md#commits)
- [x] Meets the [contributing guidelines](https://github.com/katanomi/spec/blob/main/CONTRIBUTING.md) (including
  functionality, content, code)
- [x] Test cases with documentation and functionality works as expected using current and related github repos (MUST deploy and check)
- [x] Release notes block below has been filled in or deleted (only if no user facing changes)
