### PR TITLE
support to pass labels selector when select secret

### DIFF
--- a/secret/get_secret_test.go
+++ b/secret/get_secret_test.go
@@ -44,10 +44,10 @@ var _ = Describe("Test.GetSecretByRefOrLabel", func() {
 	BeforeEach(func() {
 		ctx = context.TODO()
 		ref = &corev1.ObjectReference{
-			Namespace: testNamespace,
+			Namespace: "default",
 			Name:      "secret-name",
 		}
-		clt = fake.NewClientBuilder().WithScheme(testK8sClient.Scheme()).Build()
+		clt = fake.NewClientBuilder().WithScheme(scheme).Build()
 		ctx = pkgClient.WithClient(context.Background(), clt)
 	})
 
@@ -79,7 +79,7 @@ var _ = Describe("Test.GetSecretByRefOrLabel", func() {
 		When("ref namespace is empty", func() {
 			BeforeEach(func() {
 				ref.Namespace = ""
-				ctx = pkgnamespace.WithNamespace(ctx, testNamespace)
+				ctx = pkgnamespace.WithNamespace(ctx, "default")
 			})
 			It("should return secret", func() {
 				Expect(err).Should(BeNil())

--- a/secret/secret_suite_test.go
+++ b/secret/secret_suite_test.go
@@ -19,13 +19,12 @@ package secret
 import (
 	"testing"
 
+	"k8s.io/apimachinery/pkg/runtime"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/client-go/kubernetes/scheme"
-	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/envtest"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 )
@@ -35,31 +34,17 @@ func TestSecret(t *testing.T) {
 	RunSpecs(t, "Secret Suite")
 }
 
-var testNamespace = "default"
-var testK8sClient client.Client
-var testEnv *envtest.Environment
+var scheme = runtime.NewScheme()
+
+func init() {
+	corev1.AddToScheme(scheme)
+}
+
 var testLogger = zap.NewRaw(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)).Sugar()
 
 var _ = BeforeSuite(func() {
 	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
-
-	By("bootstrapping test environment")
-	testEnv = &envtest.Environment{}
-
-	cfg, err := testEnv.Start()
-	Expect(err).NotTo(HaveOccurred())
-	Expect(cfg).NotTo(BeNil())
-
-	err = corev1.AddToScheme(scheme.Scheme)
-	Expect(err).NotTo(HaveOccurred())
-
-	// +kubebuilder:scaffold:scheme
-	testK8sClient, err = client.New(cfg, client.Options{Scheme: scheme.Scheme})
-	Expect(err).NotTo(HaveOccurred())
-	Expect(testK8sClient).NotTo(BeNil())
 })
 
 var _ = AfterSuite(func() {
-	err := testEnv.Stop()
-	Expect(err).NotTo(HaveOccurred())
 })


### PR DESCRIPTION
Signed-off-by: jtcheng <jtcheng@alauda.io>

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

support to pass labels selector when select secret

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [`spec` PR link](https://github.com/katanomi/spec) included
- [ ] Follows the [commit message standard](https://github.com/katanomi/spec/blob/main/CONTRIBUTING.md#commits)
- [ ] Meets the [contributing guidelines](https://github.com/katanomi/spec/blob/main/CONTRIBUTING.md) (including
  functionality, content, code)
- [x] Test cases with documentation and functionality works as expected using current and related github repos (MUST deploy and check)
- [ ] Release notes block below has been filled in or deleted (only if no user facing changes)

# Release Notes


```release-note
NONE
```
