### PR TITLE
Add configuration for k8s client config timeout (#296)

### DIFF
--- a/client/defaults_test.go
+++ b/client/defaults_test.go
@@ -14,30 +14,30 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package check
+package client
 
 import (
-	"context"
+	"os"
 	"testing"
+	"time"
 
 	. "github.com/onsi/gomega"
-	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
-func TestInstalledTekton(t *testing.T) {
-	testCases := []struct {
-		clt  *fake.ClientBuilder
-		want bool
-	}{
-		{
-			clt:  fake.NewClientBuilder(),
-			want: false,
-		},
-	}
+func TestNewDefaultClientWithTimeOut(t *testing.T) {
 	g := NewGomegaWithT(t)
-	for _, tt := range testCases {
-		client := tt.clt.Build()
-		result := InstalledTekton(context.TODO(), client)
-		g.Expect(result).To(Equal(tt.want))
-	}
+
+	os.Setenv("HTTP_CLIENT_TIMEOUT", "20")
+	client := NewHTTPClient()
+
+	g.Expect(client.Timeout).To(Equal(20 * time.Second))
+}
+
+func TestNewDefaultClientWithDefaultTimeOut(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	os.Unsetenv("HTTP_CLIENT_TIMEOUT")
+	client := NewHTTPClient()
+
+	g.Expect(client.Timeout).To(Equal(30 * time.Second))
 }

--- a/sharedmain/app.go
+++ b/sharedmain/app.go
@@ -76,6 +76,7 @@ var (
 	DefaultTimeout = kclient.DefaultTimeout
 	DefaultQPS     = kclient.DefaultQPS
 	DefaultBurst   = kclient.DefaultBurst
+	Timeout        time.Duration
 	Burst          int
 	QPS            float64
 	ConfigFile     string
@@ -129,6 +130,9 @@ type AppBuilder struct {
 
 // ParseFlag parse flag needed for App
 func ParseFlag() {
+	flag.DurationVar(&Timeout, "kube-api-timeout", DefaultTimeout,
+		"The maximum length of time to wait before giving up on a server request."+
+			"A value of zero means no timeout. DefaultTimeOut: 10s")
 	flag.Float64Var(&QPS, "kube-api-qps", float64(DefaultQPS),
 		"qps indicates the maximum QPS to the master from this client."+
 			"If it's zero, the created RESTClient will use DefaultQPS: 50")
@@ -154,9 +158,8 @@ func (a *AppBuilder) init() {
 		ParseFlag()
 		a.Context = ctrl.SetupSignalHandler()
 		a.Context, a.Config = GetConfigOrDie(a.Context)
-		if a.Config.Timeout == 0 {
-			a.Config.Timeout = DefaultTimeout
-		}
+		a.Config.Timeout = Timeout
+
 		if a.Config.QPS < float32(QPS) {
 			a.Config.QPS = float32(QPS)
 		}

--- a/sharedmain/sharedmain_suite_test.go
+++ b/sharedmain/sharedmain_suite_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package sharedmain_test
+package sharedmain
 
 import (
 	"testing"

--- a/sharedmain/sharedmain_test.go
+++ b/sharedmain/sharedmain_test.go
@@ -14,22 +14,46 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package sharedmain_test
+package sharedmain
 
 import (
-	"github.com/katanomi/pkg/sharedmain"
+	"flag"
+	"time"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
 
-var _ = Describe("Sharedmain", func() {
-	Context("ParseFlag should work as except", func() {
-		It("If flag is not provided,should return the default value", func() {
-			sharedmain.ParseFlag()
-			Expect(sharedmain.QPS).To(Equal(float64(sharedmain.DefaultQPS)))
-			Expect(sharedmain.Burst).To(Equal(sharedmain.DefaultBurst))
-			Expect(sharedmain.ConfigFile).To(Equal(""))
+var _ = BeforeSuite(func() {
+	ParseFlag()
+})
 
+var _ = Describe("ParseFlag", func() {
+
+	When("flag not provided", func() {
+		It("return default values", func() {
+			Expect(QPS).To(Equal(float64(DefaultQPS)))
+			Expect(Burst).To(Equal(DefaultBurst))
+			Expect(Timeout).To(Equal(DefaultTimeout))
+			Expect(ConfigFile).To(Equal(""))
 		})
 	})
+
+	When("flag proviede", func() {
+		BeforeEach(func() {
+			flag.CommandLine.Parse([]string{
+				"--kube-api-timeout", "20s",
+				"--kube-api-qps", "80",
+				"--kube-api-burst", "90",
+				"--config", "config",
+			})
+		})
+		It("return configured values", func() {
+			Expect(QPS).To(Equal(float64(80)))
+			Expect(Burst).To(Equal(90))
+			Expect(Timeout).To(Equal(20 * time.Second))
+			Expect(ConfigFile).To(Equal("config"))
+		})
+	})
+
 })


### PR DESCRIPTION
Previously, value of timeout can not be configured and is 10s as default value.

Now add the falg kube-api-timeout that can be configured by falg.

Signed-off-by: yuzhipeng <yuzp1996@qq.com>

Signed-off-by: yuzhipeng <yuzp1996@qq.com>

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!--
Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)!

-->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [`spec` PR link](https://github.com/katanomi/spec) included
- [ ] Follows the [commit message standard](https://github.com/katanomi/spec/blob/main/CONTRIBUTING.md#commits)
- [ ] Meets the [contributing guidelines](https://github.com/katanomi/spec/blob/main/CONTRIBUTING.md) (including
  functionality, content, code)
- [ ] Test cases with documentation and functionality works as expected using current and related github repos (MUST deploy and check)
- [ ] Release notes block below has been filled in or deleted (only if no user facing changes)

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->