### PR TITLE
feat: resource url support automatic select secret

### DIFF
--- a/apis/meta/v1alpha1/resource_object_types.go
+++ b/apis/meta/v1alpha1/resource_object_types.go
@@ -51,13 +51,16 @@ type ResourceURL struct {
 
 	// SecretRef stores a reference to a secret object
 	// that contain authentication data for the described resource
-	SecretRef *corev1.ObjectReference `json:"secretRef"`
+	// If not specified, it will automatically match based on the url.
+	// If not matched, it will cause the failed state.
+	// +optional
+	SecretRef *corev1.ObjectReference `json:"secretRef,omitempty"`
 }
 
 // Validate basic validation for ResourceURL
 func (r *ResourceURL) Validate(path *field.Path) field.ErrorList {
 	errs := field.ErrorList{}
 	errs = append(errs, kvalidation.ValidateURL(r.URL, path.Child("url"))...)
-	errs = append(errs, kvalidation.ValidateObjectReference(r.SecretRef, false, false, path.Child("secretRef"))...)
+	errs = append(errs, kvalidation.ValidateObjectReference(r.SecretRef, true, false, path.Child("secretRef"))...)
 	return errs
 }

--- a/apis/meta/v1alpha1/resource_object_types_test.go
+++ b/apis/meta/v1alpha1/resource_object_types_test.go
@@ -1,0 +1,61 @@
+/*
+Copyright 2022 The Katanomi Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha1
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	. "github.com/katanomi/pkg/testing"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+)
+
+var _ = Describe("Test.ResourceURL.Validate", func() {
+
+	var (
+		resourceURL *ResourceURL
+		errs        field.ErrorList
+		path        *field.Path
+	)
+
+	BeforeEach(func() {
+		resourceURL = &ResourceURL{}
+		errs = nil
+		path = field.NewPath("spec")
+	})
+
+	JustBeforeEach(func() {
+		errs = resourceURL.Validate(path)
+	})
+
+	Context("empty resource url", func() {
+		It("should return an error", func() {
+			Expect(errs).ToNot(BeNil())
+			Expect(errs).To(HaveLen(1))
+		})
+	})
+
+	Context("valid resource url", func() {
+		BeforeEach(func() {
+			MustLoadYaml("testdata/resource_url.valid.yaml", resourceURL)
+		})
+		It("should not return an error", func() {
+			Expect(errs).To(HaveLen(0))
+		})
+	})
+
+})

--- a/apis/meta/v1alpha1/testdata/resource_url.valid.yaml
+++ b/apis/meta/v1alpha1/testdata/resource_url.valid.yaml
@@ -1,0 +1,4 @@
+url: "https://github.com/katanomi/spec"
+SecretRef:
+  name: "name"
+  namespace: "default"

--- a/apis/validation/addressable_validation_test.go
+++ b/apis/validation/addressable_validation_test.go
@@ -17,8 +17,9 @@ limitations under the License.
 package validation
 
 import (
-	duckv1 "knative.dev/pkg/apis/duck/v1"
 	"testing"
+
+	duckv1 "knative.dev/pkg/apis/duck/v1"
 
 	. "github.com/onsi/gomega"
 	"k8s.io/apimachinery/pkg/util/validation/field"

--- a/secret/get_secret_test.go
+++ b/secret/get_secret_test.go
@@ -86,6 +86,16 @@ var _ = Describe("Test.GetSecretByRefOrLabel", func() {
 				Expect(secret.GetName()).Should(Equal("secret-name"))
 			})
 		})
+		When("ref and ctx namespace both empty", func() {
+			BeforeEach(func() {
+				ref.Namespace = ""
+				ctx = pkgnamespace.WithNamespace(ctx, "")
+			})
+			It("should return error", func() {
+				Expect(err).ShouldNot(BeNil())
+				Expect(err).Should(Equal(namespaceIsEmpty))
+			})
+		})
 	})
 
 	Context("get secret by labels", func() {


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes
* feat: resource url support automatic select secret
* fix: select secret in correct namespace
<!--
Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)!

-->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [`spec` PR link](https://github.com/katanomi/spec) included
- [x] Follows the [commit message standard](https://github.com/katanomi/spec/blob/main/CONTRIBUTING.md#commits)
- [x] Meets the [contributing guidelines](https://github.com/katanomi/spec/blob/main/CONTRIBUTING.md) (including
  functionality, content, code)
- [x] Test cases with documentation and functionality works as expected using current and related github repos (MUST deploy and check)
- [x] Release notes block below has been filled in or deleted (only if no user facing changes)
