### PR TITLE
support select secret by scene

### DIFF
--- a/apis/meta/v1alpha1/labels_annotations.go
+++ b/apis/meta/v1alpha1/labels_annotations.go
@@ -51,6 +51,11 @@ const (
 	// IntegrationSecretApplyNamespaces annotation key to store apply namespace for current secret
 	IntegrationSecretApplyNamespaces = "integrations.katanomi.dev/secret.applyNamespaces"
 
+	// IntegrationSecretResourcePathFmt annotation indicates resource path format for current secret
+	IntegrationSecretResourcePathFmt = "integrations.katanomi.dev/secret.resourcePathFmt"
+	// IntegrationSecretSubResourcePathFmt annotation indicates sub resource path format for current secret
+	IntegrationSecretSubResourcePathFmt = "integrations.katanomi.dev/secret.subResourcePathFmt"
+
 	// SecretSyncMutationLabelKey label key to select the suitable secret
 	SecretSyncMutationLabelKey = "integrations.katanomi.dev/integration.mutation"
 
@@ -100,7 +105,22 @@ const (
 	MethodsAttributeKey                = "methods"
 	AllowEmptySecretAttributeKey       = "allowEmptySecret"
 	DefaultProjectTypeAttributeKey     = "defaultProjectSubType"
-	ResourcePathFormat                 = "resourcePathFormat"
+	// ResourcePathFormat indicates project path format,
+	// eg. maven project access url is /repository/maven
+	// the value should be a json string like
+	// {
+	// 	"web-console": "/repository/%s",
+	// 	"api": "/api/repository/%s",
+	// }
+	ResourcePathFormatAttributeKey = "resourcePathFormat"
+	// SubResourcePathFormat indicates sub resource path format,
+	// eg. bitbucket project access url is /scm/devops/demo
+	// the value should be a json string like
+	// {
+	// 	"http-clone": "/scm/%s/%s",
+	// 	"web-console": "/projects/%s/repo/%s",
+	// }
+	SubResourcePathFormatAttributeKey = "subResourcePathFormat"
 	// GitPRRevisionPrefixes allows git related integrations
 	// define custom PR revision prefixes
 	GitPRRevisionPrefixes = "gitPRRevisionPrefixes"

--- a/apis/meta/v1alpha1/resourcepath_scene.go
+++ b/apis/meta/v1alpha1/resourcepath_scene.go
@@ -24,4 +24,6 @@ const (
 	ResourcePathSceneAPI ResourcePathScene = "api"
 	// ResourcePathSceneWebConsole resource path scene for web page
 	ResourcePathSceneWebConsole ResourcePathScene = "web-console"
+	// ResourcePathSceneHttpClone resource path scene for http clone url for git
+	ResourcePathSceneHttpClone ResourcePathScene = "http-clone"
 )

--- a/plugin/client/interface.go
+++ b/plugin/client/interface.go
@@ -66,6 +66,8 @@ type AdditionalWebhookRegister interface {
 type ResourcePathFormatter interface {
 	// GetResourcePathFmt resource path format
 	GetResourcePathFmt() map[metav1alpha1.ResourcePathScene]string
+	// GetSubResourcePathFmt resource path format
+	GetSubResourcePathFmt() map[metav1alpha1.ResourcePathScene]string
 }
 
 // AuthChecker implements an authorization check method for plugins


### PR DESCRIPTION
Signed-off-by: jtcheng <jtcheng@alauda.io>

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

support select secret by scene

1. different http clone url used by different git tools, we should match the resource scope according http-clone url pattern. 
     eg. bitbucket http clone url has a prefix of /scm, so we should match secret according such  resource url pattern
 
# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] [`spec` PR link](https://github.com/katanomi/spec/pull/186) included
- [ ] Follows the [commit message standard](https://github.com/katanomi/spec/blob/main/CONTRIBUTING.md#commits)
- [ ] Meets the [contributing guidelines](https://github.com/katanomi/spec/blob/main/CONTRIBUTING.md) (including
  functionality, content, code)
- [x] Test cases with documentation and functionality works as expected using current and related github repos (MUST deploy and check)
- [ ] Release notes block below has been filled in or deleted (only if no user facing changes)

# Release Notes

```release-note
`feature`: support select secret by scenario
```