### PR TITLE
Replace manger config ns and name with system.Namespace() and Name()

### DIFF
--- a/config/manager.go
+++ b/config/manager.go
@@ -82,10 +82,16 @@ func (manager *Manager) GetConfig() *Config {
 }
 
 func (manager *Manager) applyConfig(cm *corev1.ConfigMap) {
-	if cm == nil || cm.Data == nil {
-		manager.Logger.Errorw("configmap or configmap.data is null", "configmap", fmt.Sprintf("%s/%s", cm.Namespace, cm.Name))
+	// Almost never reach here since applyConfig will be called
+	// only after the watched configmap has been transformed
+	if cm == nil {
 		return
 	}
+	if cm.Data == nil {
+		manager.Logger.Errorw("config manager configmap data is nil", "configmap", fmt.Sprintf("%s/%s", cm.Namespace, cm.Name))
+		return
+	}
+
 	manager.lock.Lock()
 	defer manager.lock.Unlock()
 	// whole replacement

--- a/config/manager_test.go
+++ b/config/manager_test.go
@@ -35,7 +35,7 @@ import (
 var _ = Describe("NewManger and GetConfig", func() {
 
 	var (
-		oldCM      *corev1.ConfigMap
+		configmap      *corev1.ConfigMap
 		logger     *zap.Logger
 		manager    *Manager
 		watcher    *informer.InformedWatcher
@@ -47,7 +47,7 @@ var _ = Describe("NewManger and GetConfig", func() {
 	BeforeEach(func() {
 		ns = "default"
 		cmName = "cm"
-		oldCM = &corev1.ConfigMap{
+		configmap = &corev1.ConfigMap{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      cmName,
 				Namespace: ns,
@@ -55,7 +55,7 @@ var _ = Describe("NewManger and GetConfig", func() {
 		}
 		logger, _ = zap.NewDevelopment()
 
-		client := fake.NewSimpleClientset(oldCM)
+		client := fake.NewSimpleClientset(configmap)
 		watcher = informer.NewInformedWatcher(client, ns)
 
 		manager = NewManager(watcher, logger.Sugar(), cmName)
@@ -65,7 +65,6 @@ var _ = Describe("NewManger and GetConfig", func() {
 		if err := watcher.Start(stopCh); err != nil {
 			logger.Fatal("failed to start watcher", zap.Error(err))
 		}
-
 	})
 
 	JustAfterEach(func() {

--- a/sharedmain/sharedmain_test.go
+++ b/sharedmain/sharedmain_test.go
@@ -36,6 +36,7 @@ var _ = Describe("ParseFlag", func() {
 			Expect(Burst).To(Equal(DefaultBurst))
 			Expect(Timeout).To(Equal(DefaultTimeout))
 			Expect(ConfigFile).To(Equal(""))
+			Expect(InsecureSkipVerify).To(Equal(false))
 		})
 	})
 
@@ -46,6 +47,7 @@ var _ = Describe("ParseFlag", func() {
 				"--kube-api-qps", "80",
 				"--kube-api-burst", "90",
 				"--config", "config",
+				"--insecure-skip-tls-verify", "true",
 			})
 		})
 		It("return configured values", func() {
@@ -53,6 +55,7 @@ var _ = Describe("ParseFlag", func() {
 			Expect(Burst).To(Equal(90))
 			Expect(Timeout).To(Equal(20 * time.Second))
 			Expect(ConfigFile).To(Equal("config"))
+			Expect(InsecureSkipVerify).To(Equal(true))
 		})
 	})
 


### PR DESCRIPTION
If cm is nil there will be a panic. So we need replace it in case trigger the panic.

Signed-off-by: yuzhipeng <zpyu@alauda.io>

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!--
Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)!

-->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [`spec` PR link](https://github.com/katanomi/spec) included
- [ ] Follows the [commit message standard](https://github.com/katanomi/spec/blob/main/CONTRIBUTING.md#commits)
- [ ] Meets the [contributing guidelines](https://github.com/katanomi/spec/blob/main/CONTRIBUTING.md) (including
  functionality, content, code)
- [ ] Test cases with documentation and functionality works as expected using current and related github repos (MUST deploy and check)
- [ ] Release notes block below has been filled in or deleted (only if no user facing changes)

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->