### PR TITLE
chore: rename ociContainerImageBuild-url

### DIFF
--- a/command/options/oci_container_image_build.go
+++ b/command/options/oci_container_image_build.go
@@ -20,12 +20,12 @@ import (
 	"github.com/spf13/pflag"
 )
 
-// OCIContainerImageBuildURLOption describe ociContainerImageBuild-url option
-type OCIContainerImageBuildURLOption struct {
+// ResultsOCIContainerImageBuildURLOption describe ociContainerImageBuild-url option
+type ResultsOCIContainerImageBuildURLOption struct {
 	OciContainerImageBuildUrl string
 }
 
 // AddFlags add flags to options
-func (m *OCIContainerImageBuildURLOption) AddFlags(flags *pflag.FlagSet) {
-	flags.StringVar(&m.OciContainerImageBuildUrl, "ociContainerImageBuild-url", "ociContainerImageBuild-url", `the path to save ociContainerImageBuild-url, details: https://github.com/katanomi/spec/blob/main/docs/core/contracts/3.core.task-contracts.ociContainerImageBuild.md#results`)
+func (m *ResultsOCIContainerImageBuildURLOption) AddFlags(flags *pflag.FlagSet) {
+	flags.StringVar(&m.OciContainerImageBuildUrl, "results-ociContainerImageBuild-url", "", `the path to save ociContainerImageBuild-url, details: https://github.com/katanomi/spec/blob/main/docs/core/contracts/3.core.task-contracts.ociContainerImageBuild.md#results`)
 }


### PR DESCRIPTION

# Changes

rename ociContainerImageBuild-url to results-ociContainerImageBuild-url

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [`spec` PR link](https://github.com/katanomi/spec) included
- [x] Follows the [commit message standard](https://github.com/katanomi/spec/blob/main/CONTRIBUTING.md#commits)
- [x] Meets the [contributing guidelines](https://github.com/katanomi/spec/blob/main/CONTRIBUTING.md) (including
  functionality, content, code)
- [x] Test cases with documentation and functionality works as expected using current and related github repos (MUST deploy and check)
- [x] Release notes block below has been filled in or deleted (only if no user facing changes)
