### PR TITLE
fix: zero test result

### DIFF
--- a/apis/codequality/v1alpha1/unit_tests_funcs.go
+++ b/apis/codequality/v1alpha1/unit_tests_funcs.go
@@ -65,7 +65,7 @@ func (t *TestResult) IsEmpty() bool {
 	if t == nil {
 		return true
 	}
-	return t.Failed+t.Passed+t.Skipped == 0
+	return t.Failed+t.Passed+t.Skipped == 0 && t.PassedTestsRate == ""
 }
 
 // GetObjectWithValues inits an object based on a json.path values map

--- a/apis/codequality/v1alpha1/unit_tests_funcs_test.go
+++ b/apis/codequality/v1alpha1/unit_tests_funcs_test.go
@@ -124,6 +124,12 @@ func TestUnitTestsResultIsEmpty(t *testing.T) {
 		g.Expect(object.IsEmpty()).To(gomega.BeFalse())
 	})
 
+	t.Run("has results with zero values", func(t *testing.T) {
+		g := gomega.NewGomegaWithT(t)
+		object := UnitTestsResult{TestResult: &TestResult{PassedTestsRate: "0.00"}}
+		g.Expect(object.IsEmpty()).To(gomega.BeFalse())
+	})
+
 	t.Run("nil results with coverage", func(t *testing.T) {
 		g := gomega.NewGomegaWithT(t)
 		object := UnitTestsResult{Coverage: &TestCoverage{Lines: "1"}}


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes
- fix: zero test result
Allow IsEmpty returns false even if there is no test cases included in a test execution(failed, passed, skipped are all 0), provided that PassedTestsRate is not empty string.

Scenario:  Expect below task result could be injected into buildRun.status rather than omitted.
```
testResults:
  failed: 0
  passed: 0
  passedTestsRate: "0.00"
  skipped: 0
```
```
apiVersion: builds.katanomi.dev/v1alpha1
kind: BuildRun
metadata:
  name: katanomi-adefs
  namespace: default
status:
  unitTestsResults:
    - name: existing-result
      coverage:
        lines: "11"
        branches: "11.33"
    - name: unittest // this item will be omitted if IsEmpty returns true in this scenario.
      testResults:
        passed: 0
        skipped: 0
        failed: 0
        passedTestsRate: "0.00"
```

<!--
Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)!

-->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [`spec` PR link](https://github.com/katanomi/spec) included
- [ ] Follows the [commit message standard](https://github.com/katanomi/spec/blob/main/CONTRIBUTING.md#commits)
- [ ] Meets the [contributing guidelines](https://github.com/katanomi/spec/blob/main/CONTRIBUTING.md) (including
  functionality, content, code)
- [ ] Test cases with documentation and functionality works as expected using current and related github repos (MUST deploy and check)
- [ ] Release notes block below has been filled in or deleted (only if no user facing changes)
