### PR TITLE
Add GetPipelineRunOwner for getting piplinerun owner for taskrun

### DIFF
--- a/tekton/taskrun_filter_completion.go
+++ b/tekton/taskrun_filter_completion.go
@@ -16,8 +16,13 @@ limitations under the License.
 
 package tekton
 
-import "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
+import (
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline"
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
 
+// FilterCompletedTaskRun will filter completed taskrun
 func FilterCompletedTaskRun(list *v1beta1.TaskRunList) {
 	items := list.Items
 	for i := 0; i < len(items); i++ {
@@ -29,8 +34,20 @@ func FilterCompletedTaskRun(list *v1beta1.TaskRunList) {
 	list.Items = items
 }
 
+//  IsCompletedTaskRun return true if taskrun is completed
 func IsCompletedTaskRun(taskRun v1beta1.TaskRun) bool {
 	// When taskRun is Done the completionTime should be set
 	// In case completionTime is nil cause crash we check if completionTime is nil here.
 	return taskRun.IsDone() && taskRun.Status.CompletionTime != nil
+}
+
+// GetPipelineRunOwner return pipelinerun owner for taskrun if exist
+func GetPipelineRunOwner(taskrun v1beta1.TaskRun) (exist bool, owner metav1.OwnerReference) {
+
+	for _, o := range taskrun.OwnerReferences {
+		if o.Kind == pipeline.PipelineRunControllerName {
+			return true, o
+		}
+	}
+	return false, metav1.OwnerReference{}
 }

--- a/tekton/taskrun_test.go
+++ b/tekton/taskrun_test.go
@@ -174,7 +174,47 @@ var _ = Describe("FilterCompletedTaskRun", func() {
 		})
 		It("should return TaskRun 3", func() {
 			Expect(taskRunList).To(Equal(expectList))
+		})
+	})
+})
 
+var _ = Describe("GetPipelineRunOwner", func() {
+
+	type result struct {
+		taskrun pipelinev1beta1.TaskRun
+		exist   bool
+		prName  string
+	}
+
+	var (
+		withOwnerTR, noOwnerTR pipelinev1beta1.TaskRun
+		expects                []result
+	)
+
+	BeforeEach(func() {
+		Expect(ktesting.LoadYAML("testdata/TaskRun.WithOwner.yaml", &withOwnerTR)).To(Succeed())
+		Expect(ktesting.LoadYAML("testdata/TaskRun.Completed.yaml", &noOwnerTR)).To(Succeed())
+		expects = []result{
+			{
+				withOwnerTR,
+				true,
+				"complete",
+			},
+			{
+				noOwnerTR,
+				false,
+				"",
+			},
+		}
+	})
+
+	Context("return owner if exist", func() {
+		It("return owner as expect", func() {
+			for _, r := range expects {
+				exist, owner := GetPipelineRunOwner(r.taskrun)
+				Expect(exist).To(Equal(r.exist))
+				Expect(owner.Name).To(Equal(r.prName))
+			}
 		})
 	})
 })

--- a/tekton/testdata/TaskRun.WithOwner.yaml
+++ b/tekton/testdata/TaskRun.WithOwner.yaml
@@ -1,0 +1,13 @@
+apiVersion: tekton.dev/v1beta1
+kind: TaskRun
+metadata:
+  labels:
+    katanomi.dev/managedBy: katanomi
+  name: with-owner
+  namespace: devops
+  ownerReferences:
+  - apiVersion: tekton.dev/v1beta1
+    blockOwnerDeletion: true
+    controller: true
+    kind: PipelineRun
+    name: complete


### PR DESCRIPTION
GetPipelineRunOwner will return pipelinerun Owner for taskrun if exist

Signed-off-by: yuzhipeng <zpyu@alauda.io>

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!--
Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)!

-->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [`spec` PR link](https://github.com/katanomi/spec) included
- [ ] Follows the [commit message standard](https://github.com/katanomi/spec/blob/main/CONTRIBUTING.md#commits)
- [ ] Meets the [contributing guidelines](https://github.com/katanomi/spec/blob/main/CONTRIBUTING.md) (including
  functionality, content, code)
- [ ] Test cases with documentation and functionality works as expected using current and related github repos (MUST deploy and check)
- [ ] Release notes block below has been filled in or deleted (only if no user facing changes)

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->