### PR TITLE
Retrun nil if input nil for FromTopLevelConditonObject

### DIFF
--- a/apis/meta/v1alpha1/objectcondition_types.go
+++ b/apis/meta/v1alpha1/objectcondition_types.go
@@ -17,6 +17,7 @@ limitations under the License.
 package v1alpha1
 
 import (
+	"github.com/katanomi/pkg/pointer"
 	corev1 "k8s.io/api/core/v1"
 	"knative.dev/pkg/apis"
 )
@@ -38,6 +39,9 @@ func (o ObjectCondition) IsTheSame(obj ObjectCondition) bool {
 }
 
 func (o *ObjectCondition) FromTopLevelConditionObject(obj TopLevelConditionObject) *ObjectCondition {
+	if pointer.IsNil(obj) {
+		return nil
+	}
 	if obj.GetTopLevelCondition() != nil {
 		o.Condition = *obj.GetTopLevelCondition()
 	}

--- a/apis/meta/v1alpha1/objectcondition_types_test.go
+++ b/apis/meta/v1alpha1/objectcondition_types_test.go
@@ -105,3 +105,10 @@ func TestDeepCopy(t *testing.T) {
 
 	g.Expect(cmp.Diff(&abcPod, abcPod.DeepCopy())).To(BeEmpty())
 }
+
+func TestObjectConditionFromTopLevelConditionObject(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	objcs := &ObjectCondition{}
+	g.Expect(objcs.FromTopLevelConditionObject(nil)).To(BeNil())
+}

--- a/pointer/interfaces.go
+++ b/pointer/interfaces.go
@@ -1,0 +1,23 @@
+/*
+Copyright 2022 The Katanomi Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package pointer
+
+import "reflect"
+
+// IsNil will judge if the input object is a real nil
+func IsNil(v interface{}) bool {
+	return v == nil || (reflect.ValueOf(v).Kind() == reflect.Ptr && reflect.ValueOf(v).IsNil())
+}

--- a/pointer/interfaces_test.go
+++ b/pointer/interfaces_test.go
@@ -1,0 +1,50 @@
+/*
+Copyright 2021 The Katanomi Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package pointer
+
+import (
+	"testing"
+)
+
+func TestIsNil(T *testing.T) {
+	type test struct {
+		name   string
+		input  interface{}
+		expect bool
+	}
+
+	type testWarp struct {
+		input *test
+	}
+	tests := []test{
+		{"nil", nil, true},
+		{"nil string", "nil", false},
+
+		{"test{}", test{}, false},
+		{"&test{}", &test{}, false},
+
+		{"test{input:nil}", test{input: nil}, false},
+		{"&test{input:nil}", &test{input: nil}, false},
+
+		{"testWarp", testWarp{nil}, false},
+		{"&testWarp", &testWarp{nil}, false},
+	}
+	for _, t := range tests {
+		if r := IsNil(t.input); r != t.expect {
+			T.Errorf("expect %v but get %v for %s", t.expect, r, t.name)
+		}
+	}
+}


### PR DESCRIPTION
Retrun nil if input nil for FromTopLevelConditonObject or every caller have to check the input parameters.

Signed-off-by: yuzhipeng <zpyu@alauda.io>

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!--
Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)!

-->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [`spec` PR link](https://github.com/katanomi/spec) included
- [ ] Follows the [commit message standard](https://github.com/katanomi/spec/blob/main/CONTRIBUTING.md#commits)
- [ ] Meets the [contributing guidelines](https://github.com/katanomi/spec/blob/main/CONTRIBUTING.md) (including
  functionality, content, code)
- [ ] Test cases with documentation and functionality works as expected using current and related github repos (MUST deploy and check)
- [ ] Release notes block below has been filled in or deleted (only if no user facing changes)

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->