### PR TITLE
fix: artifact  promotion approval timed out because required fields b…

### DIFF
--- a/apis/meta/v1alpha1/approve_types.go
+++ b/apis/meta/v1alpha1/approve_types.go
@@ -87,7 +87,8 @@ type UserApproval struct {
 // UserApprovalInput user input for a specific approval
 type UserApprovalInput struct {
 	// Approved user approval decision
-	Approved bool `json:"approved"`
+	// +optional
+	Approved bool `json:"approved,omitempty"`
 
 	// Description for given deicision
 	// +optional


### PR DESCRIPTION

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes
The approved field became a required field, which resulted in the failure to update the approval of the product promotion form, and eventually caused the approval timeout function to be abnormal.

<!--
Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)!

-->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [`spec` PR link](https://github.com/katanomi/spec) included
- [x] Follows the [commit message standard](https://github.com/katanomi/spec/blob/main/CONTRIBUTING.md#commits)
- [ ] Meets the [contributing guidelines](https://github.com/katanomi/spec/blob/main/CONTRIBUTING.md) (including
  functionality, content, code)
- [x] Test cases with documentation and functionality works as expected using current and related github repos (MUST deploy and check)
- [ ] Release notes block below has been filled in or deleted (only if no user facing changes)

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->