### PR TITLE
Delete transform for creating when adding approval operator

### DIFF
--- a/testing/mock/github.com/katanomi/pkg/webhook/admission/approval.go
+++ b/testing/mock/github.com/katanomi/pkg/webhook/admission/approval.go
@@ -94,20 +94,6 @@ func (mr *MockApprovalMockRecorder) GetChecks(arg0 interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetChecks", reflect.TypeOf((*MockApproval)(nil).GetChecks), arg0)
 }
 
-// GetClusterName mocks base method.
-func (m *MockApproval) GetClusterName() string {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetClusterName")
-	ret0, _ := ret[0].(string)
-	return ret0
-}
-
-// GetClusterName indicates an expected call of GetClusterName.
-func (mr *MockApprovalMockRecorder) GetClusterName() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetClusterName", reflect.TypeOf((*MockApproval)(nil).GetClusterName))
-}
-
 // GetCreationTimestamp mocks base method.
 func (m *MockApproval) GetCreationTimestamp() v1.Time {
 	m.ctrl.T.Helper()
@@ -344,18 +330,6 @@ func (mr *MockApprovalMockRecorder) SetAnnotations(arg0 interface{}) *gomock.Cal
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetAnnotations", reflect.TypeOf((*MockApproval)(nil).SetAnnotations), arg0)
 }
 
-// SetClusterName mocks base method.
-func (m *MockApproval) SetClusterName(arg0 string) {
-	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "SetClusterName", arg0)
-}
-
-// SetClusterName indicates an expected call of SetClusterName.
-func (mr *MockApprovalMockRecorder) SetClusterName(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetClusterName", reflect.TypeOf((*MockApproval)(nil).SetClusterName), arg0)
-}
-
 // SetCreationTimestamp mocks base method.
 func (m *MockApproval) SetCreationTimestamp(arg0 v1.Time) {
 	m.ctrl.T.Helper()
@@ -522,4 +496,18 @@ func (m *MockApproval) SetUID(arg0 types.UID) {
 func (mr *MockApprovalMockRecorder) SetUID(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetUID", reflect.TypeOf((*MockApproval)(nil).SetUID), arg0)
+}
+
+// SkipCreateCheck mocks base method.
+func (m *MockApproval) SkipCreateCheck() bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SkipCreateCheck")
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// SkipCreateCheck indicates an expected call of SkipCreateCheck.
+func (mr *MockApprovalMockRecorder) SkipCreateCheck() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SkipCreateCheck", reflect.TypeOf((*MockApproval)(nil).SkipCreateCheck))
 }

--- a/testing/mock/github.com/katanomi/pkg/webhook/admission/approval_with_triggeredbygetter.go
+++ b/testing/mock/github.com/katanomi/pkg/webhook/admission/approval_with_triggeredbygetter.go
@@ -94,20 +94,6 @@ func (mr *MockApprovalWithTriggeredByGetterMockRecorder) GetChecks(arg0 interfac
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetChecks", reflect.TypeOf((*MockApprovalWithTriggeredByGetter)(nil).GetChecks), arg0)
 }
 
-// GetClusterName mocks base method.
-func (m *MockApprovalWithTriggeredByGetter) GetClusterName() string {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetClusterName")
-	ret0, _ := ret[0].(string)
-	return ret0
-}
-
-// GetClusterName indicates an expected call of GetClusterName.
-func (mr *MockApprovalWithTriggeredByGetterMockRecorder) GetClusterName() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetClusterName", reflect.TypeOf((*MockApprovalWithTriggeredByGetter)(nil).GetClusterName))
-}
-
 // GetCreationTimestamp mocks base method.
 func (m *MockApprovalWithTriggeredByGetter) GetCreationTimestamp() v1.Time {
 	m.ctrl.T.Helper()
@@ -358,18 +344,6 @@ func (mr *MockApprovalWithTriggeredByGetterMockRecorder) SetAnnotations(arg0 int
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetAnnotations", reflect.TypeOf((*MockApprovalWithTriggeredByGetter)(nil).SetAnnotations), arg0)
 }
 
-// SetClusterName mocks base method.
-func (m *MockApprovalWithTriggeredByGetter) SetClusterName(arg0 string) {
-	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "SetClusterName", arg0)
-}
-
-// SetClusterName indicates an expected call of SetClusterName.
-func (mr *MockApprovalWithTriggeredByGetterMockRecorder) SetClusterName(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetClusterName", reflect.TypeOf((*MockApprovalWithTriggeredByGetter)(nil).SetClusterName), arg0)
-}
-
 // SetCreationTimestamp mocks base method.
 func (m *MockApprovalWithTriggeredByGetter) SetCreationTimestamp(arg0 v1.Time) {
 	m.ctrl.T.Helper()
@@ -536,4 +510,18 @@ func (m *MockApprovalWithTriggeredByGetter) SetUID(arg0 types.UID) {
 func (mr *MockApprovalWithTriggeredByGetterMockRecorder) SetUID(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetUID", reflect.TypeOf((*MockApprovalWithTriggeredByGetter)(nil).SetUID), arg0)
+}
+
+// SkipCreateCheck mocks base method.
+func (m *MockApprovalWithTriggeredByGetter) SkipCreateCheck() bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SkipCreateCheck")
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// SkipCreateCheck indicates an expected call of SkipCreateCheck.
+func (mr *MockApprovalWithTriggeredByGetterMockRecorder) SkipCreateCheck() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SkipCreateCheck", reflect.TypeOf((*MockApprovalWithTriggeredByGetter)(nil).SkipCreateCheck))
 }


### PR DESCRIPTION
Transform for creating eventing will add wrong operator in some case for example automate approval.

So we skip the tranfrom for the create operation.

Signed-off-by: yuzhipeng <zpyu@alauda.io>

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!--
Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)!

-->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [`spec` PR link](https://github.com/katanomi/spec) included
- [ ] Follows the [commit message standard](https://github.com/katanomi/spec/blob/main/CONTRIBUTING.md#commits)
- [ ] Meets the [contributing guidelines](https://github.com/katanomi/spec/blob/main/CONTRIBUTING.md) (including
  functionality, content, code)
- [ ] Test cases with documentation and functionality works as expected using current and related github repos (MUST deploy and check)
- [ ] Release notes block below has been filled in or deleted (only if no user facing changes)

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->