### PR TITLE
chore: add helper function to get userinfo from request context

### DIFF
--- a/apis/meta/v1alpha1/createmeta_types.go
+++ b/apis/meta/v1alpha1/createmeta_types.go
@@ -57,6 +57,9 @@ type CreatePullRequestPayload struct {
 	Target      GitBranchBaseInfo `json:"target"`
 	Title       string            `json:"title"`
 	Description string            `json:"description,omitempty"`
+
+	// indicates if the source branch should be deleted when the pull request is merged
+	RemoveSourceBranch bool `json:"removeSourceBranch,omitempty"`
 }
 
 // CreatePullRequestCommentPayload payload for create pr's Comment

--- a/user/user_suite_test.go
+++ b/user/user_suite_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 The Katanomi Authors.
+Copyright 2022 The Katanomi Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/user/user_suite_test.go
+++ b/user/user_suite_test.go
@@ -1,0 +1,29 @@
+/*
+Copyright 2021 The Katanomi Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package user
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestBuilds(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "User Suite")
+}

--- a/user/userinfo.go
+++ b/user/userinfo.go
@@ -72,3 +72,15 @@ func getUserInfoFromReq(req *restful.Request) (userinfo metav1alpha1.UserInfo, e
 	userinfo.FromJWT(claims)
 	return userinfo, errors.NewAggregate(errorList)
 }
+
+// GetBaseUserInfoFromReq get the base userinfo from the request object
+func GetBaseUserInfoFromReq(req *restful.Request) *metav1alpha1.GitUserBaseInfo {
+	userinfo, ok := UserInfoFrom(req.Request.Context())
+	if !ok {
+		return nil
+	}
+	authorInfo := &metav1alpha1.GitUserBaseInfo{}
+	authorInfo.Name = userinfo.GetName()
+	authorInfo.Email = userinfo.GetEmail()
+	return authorInfo
+}

--- a/user/userinfo_test.go
+++ b/user/userinfo_test.go
@@ -22,6 +22,9 @@ import (
 	"testing"
 
 	"github.com/emicklei/go-restful/v3"
+	metav1alpha1 "github.com/katanomi/pkg/apis/meta/v1alpha1"
+	. "github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
 )
 
 func TestGetUserInfo(t *testing.T) {
@@ -57,3 +60,42 @@ func TestGetUserInfo(t *testing.T) {
 	})
 
 }
+
+var _ = Describe("Test GetBaseUserInfoFromReq", func() {
+	var (
+		tokenString string
+		authorInfo  *metav1alpha1.GitUserBaseInfo
+	)
+	BeforeEach(func() {
+		tokenString = ""
+		authorInfo = nil
+	})
+	JustBeforeEach(func() {
+		_req := &http.Request{
+			Header: map[string][]string{},
+		}
+		_req.Header.Set("Authorization", tokenString)
+		req := &restful.Request{Request: _req}
+
+		res := &restful.Response{}
+		target := func(req *restful.Request, resp *restful.Response) {}
+		chain := &restful.FilterChain{Target: target}
+		UserInfoFilter(req, res, chain)
+
+		authorInfo = GetBaseUserInfoFromReq(req)
+	})
+
+	Context("when the request context contains the user info", func() {
+		BeforeEach(func() {
+			tokenString = "Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWUsImVtYWlsIjoiam9obkB0ZXN0LmNvbSIsImlhdCI6MTY1MzM3NzM0MCwiZXhwIjoxNjUzMzgwOTQwfQ.tT5YWrFu2F_0NWg3JFbpIaC-HbaBgJtRcff_O3Ti225RZztON1gpZOfFf06EIzWolkUrtAfrTFXonHx2rh5w8mK82kFX5sLPxiV3yDfvxU9KuE66IW_48ykFU6puBcnVMZNWUtPLHcH4OAq51zbca9eh3AFiFldnJ3YRJ85Bigky8nc1uf3CCm5c9d7P8q5SGDJZvGLHOXqQ4_aSfpX0HDTHbgw_82d7FpckeDYRdFN89LORaLRChbBM1IdfH4JvI9WtO3PDU7Ce49nMmmidhsESAalxfMrN3LIPmMz7vY0FJaBW24oA0FwJvq1Q6O_jzupMHRGS-clkUImRw185cA"
+		})
+		It("should get the username as excepted", func() {
+			gomega.Expect(authorInfo.Name).To(gomega.Equal("John Doe"))
+		})
+	})
+	Context("when the request context dose not contains the user info", func() {
+		It("should get the username as excepted", func() {
+			gomega.Expect(authorInfo).To(gomega.BeNil())
+		})
+	})
+})

--- a/user/userinfo_test.go
+++ b/user/userinfo_test.go
@@ -94,7 +94,7 @@ var _ = Describe("Test GetBaseUserInfoFromReq", func() {
 		})
 	})
 	Context("when the request context dose not contains the user info", func() {
-		It("should get the username as excepted", func() {
+		It("should get nil", func() {
 			gomega.Expect(authorInfo).To(gomega.BeNil())
 		})
 	})


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!--
Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)!

-->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] [`spec` PR link](https://github.com/katanomi/spec) included
- [x] Follows the [commit message standard](https://github.com/katanomi/spec/blob/main/CONTRIBUTING.md#commits)
- [x] Meets the [contributing guidelines](https://github.com/katanomi/spec/blob/main/CONTRIBUTING.md) (including
  functionality, content, code)
- [x] Test cases with documentation and functionality works as expected using current and related github repos (MUST deploy and check)
- [x] Release notes block below has been filled in or deleted (only if no user facing changes)

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->