### PR TITLE
remove ambiguous plugin field

### DIFF
--- a/plugin/client/auth_client.go
+++ b/plugin/client/auth_client.go
@@ -20,7 +20,6 @@ import (
 	"context"
 
 	metav1alpha1 "github.com/katanomi/pkg/apis/meta/v1alpha1"
-	corev1 "k8s.io/api/core/v1"
 	duckv1 "knative.dev/pkg/apis/duck/v1"
 )
 
@@ -32,15 +31,11 @@ type ClientAuth interface {
 
 type authClient struct {
 	client Client
-	meta   Meta
-	secret corev1.Secret
 }
 
-func newAuthClient(client Client, meta Meta, secret corev1.Secret) ClientAuth {
+func newAuthClient(client Client) ClientAuth {
 	return &authClient{
 		client: client,
-		meta:   meta,
-		secret: secret,
 	}
 }
 
@@ -49,7 +44,7 @@ func (auth *authClient) Check(ctx context.Context, baseURL *duckv1.Addressable, 
 	uri := "auth/check"
 	authCheck = &metav1alpha1.AuthCheck{}
 
-	opts = append(opts, MetaOpts(auth.meta), SecretOpts(auth.secret), ResultOpts(authCheck), BodyOpts(options))
+	opts = append(opts, ResultOpts(authCheck), BodyOpts(options))
 	err = auth.client.Post(ctx, baseURL, uri, opts...)
 	return
 }
@@ -59,7 +54,7 @@ func (auth *authClient) Token(ctx context.Context, baseURL *duckv1.Addressable, 
 	uri := "auth/token"
 	authToken = &metav1alpha1.AuthToken{}
 
-	opts = append(opts, MetaOpts(auth.meta), SecretOpts(auth.secret), ResultOpts(authToken))
+	opts = append(opts, ResultOpts(authToken))
 	err = auth.client.Post(ctx, baseURL, uri, opts...)
 	return
 }

--- a/plugin/client/blobstore.go
+++ b/plugin/client/blobstore.go
@@ -20,7 +20,6 @@ import (
 	"context"
 
 	metav1alpha1 "github.com/katanomi/pkg/apis/meta/v1alpha1"
-	corev1 "k8s.io/api/core/v1"
 	duckv1 "knative.dev/pkg/apis/duck/v1"
 )
 
@@ -30,15 +29,11 @@ type ClientBlobStore interface {
 
 type blobStore struct {
 	client Client
-	meta   Meta
-	secret corev1.Secret
 }
 
-func newBlobStore(client Client, meta Meta, secret corev1.Secret) ClientBlobStore {
+func newBlobStore(client Client) ClientBlobStore {
 	return &blobStore{
 		client: client,
-		meta:   meta,
-		secret: secret,
 	}
 }
 
@@ -46,7 +41,7 @@ func newBlobStore(client Client, meta Meta, secret corev1.Secret) ClientBlobStor
 func (p *blobStore) List(ctx context.Context, baseURL *duckv1.Addressable, options ...OptionFunc) (*metav1alpha1.BlobStoreList, error) {
 	list := &metav1alpha1.BlobStoreList{}
 
-	options = append(options, MetaOpts(p.meta), SecretOpts(p.secret), ResultOpts(list))
+	options = append(options, ResultOpts(list))
 	if err := p.client.Get(ctx, baseURL, "blobStores", options...); err != nil {
 		return nil, err
 	}

--- a/plugin/client/gitbranch.go
+++ b/plugin/client/gitbranch.go
@@ -22,7 +22,6 @@ import (
 	"github.com/katanomi/pkg/plugin/path"
 
 	metav1alpha1 "github.com/katanomi/pkg/apis/meta/v1alpha1"
-	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	duckv1 "knative.dev/pkg/apis/duck/v1"
 )
@@ -36,22 +35,18 @@ type ClientGitBranch interface {
 
 type gitBranch struct {
 	client Client
-	meta   Meta
-	secret corev1.Secret
 }
 
-func newGitBranch(client Client, meta Meta, secret corev1.Secret) ClientGitBranch {
+func newGitBranch(client Client) ClientGitBranch {
 	return &gitBranch{
 		client: client,
-		meta:   meta,
-		secret: secret,
 	}
 }
 
 // List list branch
 func (g *gitBranch) List(ctx context.Context, baseURL *duckv1.Addressable, repo metav1alpha1.GitBranchOption, options ...OptionFunc) (*metav1alpha1.GitBranchList, error) {
 	list := &metav1alpha1.GitBranchList{}
-	options = append(options, MetaOpts(g.meta), SecretOpts(g.secret), ResultOpts(list))
+	options = append(options, ResultOpts(list))
 	if repo.Repository == "" {
 		return nil, errors.NewBadRequest("repo is empty string")
 	}
@@ -65,7 +60,7 @@ func (g *gitBranch) List(ctx context.Context, baseURL *duckv1.Addressable, repo 
 // Create create branch
 func (g *gitBranch) Create(ctx context.Context, baseURL *duckv1.Addressable, payload metav1alpha1.CreateBranchPayload, options ...OptionFunc) (*metav1alpha1.GitBranch, error) {
 	branchObj := &metav1alpha1.GitBranch{}
-	options = append(options, MetaOpts(g.meta), SecretOpts(g.secret), BodyOpts(payload.CreateBranchParams), ResultOpts(branchObj))
+	options = append(options, BodyOpts(payload.CreateBranchParams), ResultOpts(branchObj))
 	if payload.Repository == "" {
 		return nil, errors.NewBadRequest("repo is empty string")
 	}
@@ -80,7 +75,7 @@ func (g *gitBranch) Create(ctx context.Context, baseURL *duckv1.Addressable, pay
 // Get branch info
 func (g *gitBranch) Get(ctx context.Context, baseURL *duckv1.Addressable, repo metav1alpha1.GitRepo, branch string, options ...OptionFunc) (*metav1alpha1.GitBranch, error) {
 	branchObj := &metav1alpha1.GitBranch{}
-	options = append(options, MetaOpts(g.meta), SecretOpts(g.secret), ResultOpts(branchObj))
+	options = append(options, ResultOpts(branchObj))
 	if repo.Repository == "" {
 		return nil, errors.NewBadRequest("repo is empty string")
 	}

--- a/plugin/client/gitcommit.go
+++ b/plugin/client/gitcommit.go
@@ -23,7 +23,6 @@ import (
 	"github.com/katanomi/pkg/plugin/path"
 
 	metav1alpha1 "github.com/katanomi/pkg/apis/meta/v1alpha1"
-	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	duckv1 "knative.dev/pkg/apis/duck/v1"
 )
@@ -36,22 +35,18 @@ type ClientGitCommit interface {
 
 type gitCommit struct {
 	client Client
-	meta   Meta
-	secret corev1.Secret
 }
 
-func newGitCommit(client Client, meta Meta, secret corev1.Secret) ClientGitCommit {
+func newGitCommit(client Client) ClientGitCommit {
 	return &gitCommit{
 		client: client,
-		meta:   meta,
-		secret: secret,
 	}
 }
 
 // Get commit info
 func (g *gitCommit) Get(ctx context.Context, baseURL *duckv1.Addressable, option metav1alpha1.GitCommitOption, options ...OptionFunc) (*metav1alpha1.GitCommit, error) {
 	commitObj := &metav1alpha1.GitCommit{}
-	options = append(options, MetaOpts(g.meta), SecretOpts(g.secret), ResultOpts(commitObj))
+	options = append(options, ResultOpts(commitObj))
 	if option.Repository == "" {
 		return nil, errors.NewBadRequest("repo is empty string")
 	} else if option.SHA == nil {
@@ -73,7 +68,7 @@ func (g *gitCommit) List(ctx context.Context, baseURL *duckv1.Addressable, optio
 	if option.Repository == "" {
 		return nil, errors.NewBadRequest("repo is empty string")
 	}
-	options = append(options, MetaOpts(g.meta), SecretOpts(g.secret), ResultOpts(result))
+	options = append(options, ResultOpts(result))
 	query := map[string]string{"ref": option.Ref}
 	if option.Since != nil {
 		query["since"] = option.Since.Format(time.RFC3339)

--- a/plugin/client/gitcommitcomment.go
+++ b/plugin/client/gitcommitcomment.go
@@ -22,7 +22,6 @@ import (
 	"github.com/katanomi/pkg/plugin/path"
 
 	metav1alpha1 "github.com/katanomi/pkg/apis/meta/v1alpha1"
-	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	duckv1 "knative.dev/pkg/apis/duck/v1"
 )
@@ -34,21 +33,17 @@ type ClientGitCommitComment interface {
 
 type gitCommitComment struct {
 	client Client
-	meta   Meta
-	secret corev1.Secret
 }
 
-func newGitCommitComment(client Client, meta Meta, secret corev1.Secret) ClientGitCommitComment {
+func newGitCommitComment(client Client) ClientGitCommitComment {
 	return &gitCommitComment{
 		client: client,
-		meta:   meta,
-		secret: secret,
 	}
 }
 
 func (g *gitCommitComment) List(ctx context.Context, baseURL *duckv1.Addressable, option metav1alpha1.GitCommitOption, options ...OptionFunc) (*metav1alpha1.GitCommitCommentList, error) {
 	commitCommentList := &metav1alpha1.GitCommitCommentList{}
-	options = append(options, MetaOpts(g.meta), SecretOpts(g.secret), ResultOpts(commitCommentList))
+	options = append(options, ResultOpts(commitCommentList))
 	if option.Repository == "" {
 		return nil, errors.NewBadRequest("repo is empty string")
 	} else if option.Project == "" {
@@ -66,7 +61,7 @@ func (g *gitCommitComment) List(ctx context.Context, baseURL *duckv1.Addressable
 
 func (g *gitCommitComment) Create(ctx context.Context, baseURL *duckv1.Addressable, payload metav1alpha1.CreateCommitCommentPayload, options ...OptionFunc) (*metav1alpha1.GitCommitComment, error) {
 	commentInfo := &metav1alpha1.GitCommitComment{}
-	options = append(options, MetaOpts(g.meta), SecretOpts(g.secret), BodyOpts(payload.CreateCommitCommentParam), ResultOpts(commentInfo))
+	options = append(options, BodyOpts(payload.CreateCommitCommentParam), ResultOpts(commentInfo))
 	if payload.Repository == "" {
 		return nil, errors.NewBadRequest("repo is empty string")
 	} else if payload.Project == "" {

--- a/plugin/client/gitcommitstatus.go
+++ b/plugin/client/gitcommitstatus.go
@@ -22,7 +22,6 @@ import (
 	"github.com/katanomi/pkg/plugin/path"
 
 	metav1alpha1 "github.com/katanomi/pkg/apis/meta/v1alpha1"
-	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	duckv1 "knative.dev/pkg/apis/duck/v1"
 )
@@ -34,21 +33,17 @@ type ClientGitCommitStatus interface {
 
 type gitCommitStatus struct {
 	client Client
-	meta   Meta
-	secret corev1.Secret
 }
 
-func newGitCommitStatus(client Client, meta Meta, secret corev1.Secret) ClientGitCommitStatus {
+func newGitCommitStatus(client Client) ClientGitCommitStatus {
 	return &gitCommitStatus{
 		client: client,
-		meta:   meta,
-		secret: secret,
 	}
 }
 
 func (g *gitCommitStatus) List(ctx context.Context, baseURL *duckv1.Addressable, option metav1alpha1.GitCommitOption, options ...OptionFunc) (*metav1alpha1.GitCommitStatusList, error) {
 	commitStatusList := &metav1alpha1.GitCommitStatusList{}
-	options = append(options, MetaOpts(g.meta), SecretOpts(g.secret), ResultOpts(commitStatusList))
+	options = append(options, ResultOpts(commitStatusList))
 	if option.Repository == "" {
 		return nil, errors.NewBadRequest("repo is empty string")
 	} else if option.Project == "" {
@@ -66,7 +61,7 @@ func (g *gitCommitStatus) List(ctx context.Context, baseURL *duckv1.Addressable,
 
 func (g *gitCommitStatus) Create(ctx context.Context, baseURL *duckv1.Addressable, payload metav1alpha1.CreateCommitStatusPayload, options ...OptionFunc) (*metav1alpha1.GitCommitStatus, error) {
 	statusInfo := &metav1alpha1.GitCommitStatus{}
-	options = append(options, MetaOpts(g.meta), SecretOpts(g.secret), BodyOpts(payload.CreateCommitStatusParam), ResultOpts(statusInfo))
+	options = append(options, BodyOpts(payload.CreateCommitStatusParam), ResultOpts(statusInfo))
 	if payload.Repository == "" {
 		return nil, errors.NewBadRequest("repo is empty string")
 	} else if payload.Project == "" {

--- a/plugin/client/gitcontent.go
+++ b/plugin/client/gitcontent.go
@@ -23,7 +23,6 @@ import (
 
 	metav1alpha1 "github.com/katanomi/pkg/apis/meta/v1alpha1"
 	"github.com/katanomi/pkg/plugin/path"
-	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	duckv1 "knative.dev/pkg/apis/duck/v1"
 )
@@ -36,21 +35,17 @@ type ClientGitContent interface {
 
 type gitContent struct {
 	client Client
-	meta   Meta
-	secret corev1.Secret
 }
 
-func newGitContent(client Client, meta Meta, secret corev1.Secret) ClientGitContent {
+func newGitContent(client Client) ClientGitContent {
 	return &gitContent{
 		client: client,
-		meta:   meta,
-		secret: secret,
 	}
 }
 
 func (g *gitContent) Get(ctx context.Context, baseURL *duckv1.Addressable, option metav1alpha1.GitRepoFileOption, options ...OptionFunc) (*metav1alpha1.GitRepoFile, error) {
 	fileInfo := &metav1alpha1.GitRepoFile{}
-	options = append(options, MetaOpts(g.meta), SecretOpts(g.secret), QueryOpts(map[string]string{"ref": option.Ref}), ResultOpts(fileInfo))
+	options = append(options, QueryOpts(map[string]string{"ref": option.Ref}), ResultOpts(fileInfo))
 	if option.Repository == "" {
 		return nil, errors.NewBadRequest("repo is empty string")
 	}
@@ -75,7 +70,7 @@ func (g *gitContent) Create(ctx context.Context, baseURL *duckv1.Addressable, pa
 	w.Close()
 	payload.Content = b.Bytes()
 
-	options = append(options, MetaOpts(g.meta), SecretOpts(g.secret), BodyOpts(payload.CreateRepoFileParams), ResultOpts(commitInfo))
+	options = append(options, BodyOpts(payload.CreateRepoFileParams), ResultOpts(commitInfo))
 	if payload.Repository == "" {
 		return nil, errors.NewBadRequest("repo is empty string")
 	}

--- a/plugin/client/gitfiletree.go
+++ b/plugin/client/gitfiletree.go
@@ -22,7 +22,6 @@ import (
 
 	"github.com/katanomi/pkg/plugin/path"
 
-	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 
 	metav1alpha1 "github.com/katanomi/pkg/apis/meta/v1alpha1"
@@ -41,16 +40,12 @@ type ClientGitRepositoryFileTree interface {
 
 type gitRepositoryFileTree struct {
 	client Client
-	meta   Meta
-	secret corev1.Secret
 }
 
 // init gitRepositoryFileTree
-func newGitRepositoryFileTree(client Client, meta Meta, secret corev1.Secret) ClientGitRepositoryFileTree {
+func newGitRepositoryFileTree(client Client) ClientGitRepositoryFileTree {
 	return &gitRepositoryFileTree{
 		client: client,
-		meta:   meta,
-		secret: secret,
 	}
 }
 
@@ -66,8 +61,6 @@ func (g *gitRepositoryFileTree) GetGitRepositoryFileTree(
 
 	options = append(
 		options,
-		MetaOpts(g.meta),
-		SecretOpts(g.secret),
 		QueryOpts(map[string]string{"path": option.Path, "tree_sha": option.TreeSha, "recursive": recursiveValue}),
 		ResultOpts(fileTree),
 	)

--- a/plugin/client/gitpullrequest.go
+++ b/plugin/client/gitpullrequest.go
@@ -23,7 +23,6 @@ import (
 	"github.com/katanomi/pkg/plugin/path"
 
 	metav1alpha1 "github.com/katanomi/pkg/apis/meta/v1alpha1"
-	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	duckv1 "knative.dev/pkg/apis/duck/v1"
 )
@@ -76,18 +75,13 @@ type GitPullRequestCRUClient interface {
 
 type gitPullRequest struct {
 	client Client
-	meta   Meta
-	secret corev1.Secret
 }
 
 func newGitPullRequest(
 	client Client,
-	meta Meta, secret corev1.Secret,
 ) GitPullRequestCRUClient {
 	return &gitPullRequest{
 		client: client,
-		meta:   meta,
-		secret: secret,
 	}
 }
 
@@ -99,7 +93,7 @@ func (g *gitPullRequest) Create(
 	options ...OptionFunc,
 ) (*metav1alpha1.GitPullRequest, error) {
 	prObj := &metav1alpha1.GitPullRequest{}
-	options = append(options, MetaOpts(g.meta), SecretOpts(g.secret), BodyOpts(payload), ResultOpts(prObj))
+	options = append(options, BodyOpts(payload), ResultOpts(prObj))
 	uri := path.Format("projects/%s/coderepositories/%s/pulls", payload.Source.Project, payload.Source.Repository)
 	if err := g.client.Post(ctx, baseURL, uri, options...); err != nil {
 		return nil, err
@@ -115,7 +109,7 @@ func (g *gitPullRequest) List(
 	options ...OptionFunc,
 ) (*metav1alpha1.GitPullRequestList, error) {
 	prList := &metav1alpha1.GitPullRequestList{}
-	options = append(options, MetaOpts(g.meta), SecretOpts(g.secret), ResultOpts(prList))
+	options = append(options, ResultOpts(prList))
 	if option.State != nil {
 		stateFilter := make(map[string]string)
 		stateFilter["state"] = (string)(*option.State)
@@ -139,7 +133,7 @@ func (g *gitPullRequest) Get(
 	options ...OptionFunc,
 ) (*metav1alpha1.GitPullRequest, error) {
 	prObj := &metav1alpha1.GitPullRequest{}
-	options = append(options, MetaOpts(g.meta), SecretOpts(g.secret), ResultOpts(prObj))
+	options = append(options, ResultOpts(prObj))
 	if option.Repository == "" {
 		return nil, errors.NewBadRequest("repo is empty string")
 	}
@@ -162,7 +156,7 @@ func (g *gitPullRequest) CreateNote(
 	options ...OptionFunc,
 ) (*metav1alpha1.GitPullRequestNote, error) {
 	noteObj := &metav1alpha1.GitPullRequestNote{}
-	options = append(options, MetaOpts(g.meta), SecretOpts(g.secret), BodyOpts(payload.CreatePullRequestCommentParam), ResultOpts(noteObj))
+	options = append(options, BodyOpts(payload.CreatePullRequestCommentParam), ResultOpts(noteObj))
 	if payload.Repository == "" {
 		return nil, errors.NewBadRequest("repo is empty string")
 	}
@@ -184,7 +178,7 @@ func (g *gitPullRequest) UpdateNote(
 	options ...OptionFunc,
 ) (*metav1alpha1.GitPullRequestNote, error) {
 	noteObj := &metav1alpha1.GitPullRequestNote{}
-	options = append(options, MetaOpts(g.meta), SecretOpts(g.secret), BodyOpts(payload.CreatePullRequestCommentParam), ResultOpts(noteObj))
+	options = append(options, BodyOpts(payload.CreatePullRequestCommentParam), ResultOpts(noteObj))
 	if payload.Repository == "" {
 		return nil, errors.NewBadRequest("repo is empty string")
 	}
@@ -211,7 +205,7 @@ func (g *gitPullRequest) ListNote(
 	options ...OptionFunc,
 ) (*metav1alpha1.GitPullRequestNoteList, error) {
 	noteList := &metav1alpha1.GitPullRequestNoteList{}
-	options = append(options, MetaOpts(g.meta), SecretOpts(g.secret), ResultOpts(noteList))
+	options = append(options, ResultOpts(noteList))
 	if option.Repository == "" {
 		return nil, errors.NewBadRequest("repo is empty string")
 	}

--- a/plugin/client/gitrepository.go
+++ b/plugin/client/gitrepository.go
@@ -22,7 +22,6 @@ import (
 	"github.com/katanomi/pkg/plugin/path"
 
 	metav1alpha1 "github.com/katanomi/pkg/apis/meta/v1alpha1"
-	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	duckv1 "knative.dev/pkg/apis/duck/v1"
 )
@@ -35,21 +34,17 @@ type ClientGitRepository interface {
 
 type gitRepository struct {
 	client Client
-	meta   Meta
-	secret corev1.Secret
 }
 
-func newGitRepository(client Client, meta Meta, secret corev1.Secret) ClientGitRepository {
+func newGitRepository(client Client) ClientGitRepository {
 	return &gitRepository{
 		client: client,
-		meta:   meta,
-		secret: secret,
 	}
 }
 
 func (g *gitRepository) List(ctx context.Context, baseURL *duckv1.Addressable, project, keyword string, subtype metav1alpha1.ProjectSubType, options ...OptionFunc) (*metav1alpha1.GitRepositoryList, error) {
 	list := &metav1alpha1.GitRepositoryList{}
-	options = append(options, MetaOpts(g.meta), SecretOpts(g.secret), QueryOpts(map[string]string{"keyword": keyword, "subtype": subtype.String()}), ResultOpts(list))
+	options = append(options, QueryOpts(map[string]string{"keyword": keyword, "subtype": subtype.String()}), ResultOpts(list))
 	if project == "" {
 		return nil, errors.NewBadRequest("project is empty string")
 	}
@@ -62,7 +57,7 @@ func (g *gitRepository) List(ctx context.Context, baseURL *duckv1.Addressable, p
 
 func (g *gitRepository) Get(ctx context.Context, baseURL *duckv1.Addressable, project, repo string, options ...OptionFunc) (*metav1alpha1.GitRepository, error) {
 	repoObj := &metav1alpha1.GitRepository{}
-	options = append(options, MetaOpts(g.meta), SecretOpts(g.secret), ResultOpts(repoObj))
+	options = append(options, ResultOpts(repoObj))
 	if project == "" {
 		return nil, errors.NewBadRequest("project is empty string")
 	}

--- a/plugin/client/gitrepotag.go
+++ b/plugin/client/gitrepotag.go
@@ -22,7 +22,6 @@ import (
 	"github.com/katanomi/pkg/plugin/path"
 
 	metav1alpha1 "github.com/katanomi/pkg/apis/meta/v1alpha1"
-	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	duckv1 "knative.dev/pkg/apis/duck/v1"
 )
@@ -35,22 +34,18 @@ type ClientGitRepositoryTag interface {
 
 type gitRepositoryTag struct {
 	client Client
-	meta   Meta
-	secret corev1.Secret
 }
 
-func newGitRepositoryTag(client Client, meta Meta, secret corev1.Secret) ClientGitRepositoryTag {
+func newGitRepositoryTag(client Client) ClientGitRepositoryTag {
 	return &gitRepositoryTag{
 		client: client,
-		meta:   meta,
-		secret: secret,
 	}
 }
 
 // Get repository tag info
 func (g *gitRepositoryTag) Get(ctx context.Context, baseURL *duckv1.Addressable, option metav1alpha1.GitRepositoryTagOption, options ...OptionFunc) (*metav1alpha1.GitRepositoryTag, error) {
 	tagObj := &metav1alpha1.GitRepositoryTag{}
-	options = append(options, MetaOpts(g.meta), SecretOpts(g.secret), ResultOpts(tagObj))
+	options = append(options, ResultOpts(tagObj))
 	if option.Repository == "" {
 		return nil, errors.NewBadRequest("repo is empty string")
 	} else if option.Tag == "" {
@@ -70,7 +65,7 @@ func (g *gitRepositoryTag) List(ctx context.Context, baseURL *duckv1.Addressable
 	if option.Repository == "" {
 		return nil, errors.NewBadRequest("repo is empty string")
 	}
-	options = append(options, MetaOpts(g.meta), SecretOpts(g.secret), ResultOpts(result))
+	options = append(options, ResultOpts(result))
 	uri := path.Format("projects/%s/coderepositories/%s/tags", option.Project, option.Repository)
 	if err := g.client.Get(ctx, baseURL, uri, options...); err != nil {
 		return nil, err

--- a/plugin/client/plugin_client.go
+++ b/plugin/client/plugin_client.go
@@ -123,7 +123,8 @@ func (p *PluginClient) WithIntegrationClassName(integrationClassName string) *Pl
 
 // Get performs a GET request using defined options
 func (p *PluginClient) Get(ctx context.Context, baseURL *duckv1.Addressable, path string, options ...OptionFunc) error {
-	options = append(defaultOptions, options...)
+	clientOptions := append(defaultOptions, MetaOpts(p.meta), SecretOpts(p.secret))
+	options = append(clientOptions, options...)
 
 	request := p.R(ctx, baseURL, options...)
 	response, err := request.Get(p.fullUrl(baseURL, path))
@@ -133,7 +134,8 @@ func (p *PluginClient) Get(ctx context.Context, baseURL *duckv1.Addressable, pat
 
 // Post performs a POST request with the given parameters
 func (p *PluginClient) Post(ctx context.Context, baseURL *duckv1.Addressable, path string, options ...OptionFunc) error {
-	options = append(defaultOptions, options...)
+	clientOptions := append(defaultOptions, MetaOpts(p.meta), SecretOpts(p.secret))
+	options = append(clientOptions, options...)
 
 	request := p.R(ctx, baseURL, options...)
 	response, err := request.Post(p.fullUrl(baseURL, path))
@@ -143,7 +145,8 @@ func (p *PluginClient) Post(ctx context.Context, baseURL *duckv1.Addressable, pa
 
 // Put performs a PUT request with the given parameters
 func (p *PluginClient) Put(ctx context.Context, baseURL *duckv1.Addressable, path string, options ...OptionFunc) error {
-	options = append(defaultOptions, options...)
+	clientOptions := append(defaultOptions, MetaOpts(p.meta), SecretOpts(p.secret))
+	options = append(clientOptions, options...)
 
 	request := p.R(ctx, baseURL, options...)
 	response, err := request.Put(p.fullUrl(baseURL, path))
@@ -153,7 +156,8 @@ func (p *PluginClient) Put(ctx context.Context, baseURL *duckv1.Addressable, pat
 
 // Delete performs a DELETE request with the given parameters
 func (p *PluginClient) Delete(ctx context.Context, baseURL *duckv1.Addressable, path string, options ...OptionFunc) error {
-	options = append(defaultOptions, options...)
+	clientOptions := append(defaultOptions, MetaOpts(p.meta), SecretOpts(p.secret))
+	options = append(clientOptions, options...)
 
 	request := p.R(ctx, baseURL, options...)
 	response, err := request.Delete(p.fullUrl(baseURL, path))
@@ -237,190 +241,228 @@ func (p *PluginClient) GitPluginClient() *GitPluginClient {
 
 // Auth provides an auth methods for clients
 func (p *PluginClient) Auth(meta Meta, secret corev1.Secret) ClientAuth {
-	return newAuthClient(p, meta, secret)
+	clone := p.Clone().WithMeta(meta).WithSecret(secret)
+
+	return newAuthClient(clone)
 }
 
 // NewAuth provides an auth methods for clients
 // Use the internal meta and secret to generate the client, please assign in advance.
 func (p *PluginClient) NewAuth() ClientAuth {
-	return newAuthClient(p, p.meta, p.secret)
+	return newAuthClient(p)
 }
 
 // Project get project client
 func (p *PluginClient) Project(meta Meta, secret corev1.Secret) ClientProject {
-	return newProject(p, meta, secret)
+	clone := p.Clone().WithMeta(meta).WithSecret(secret)
+
+	return newProject(clone)
 }
 
 // NewProject get project client
 // Use the internal meta and secret to generate the client, please assign in advance.
 func (p *PluginClient) NewProject() ClientProject {
-	return newProject(p, p.meta, p.secret)
+	return newProject(p)
 }
 
 // Repository get Repository client
 func (p *PluginClient) Repository(meta Meta, secret corev1.Secret) ClientRepository {
-	return newRepository(p, meta, secret)
+	clone := p.Clone().WithMeta(meta).WithSecret(secret)
+
+	return newRepository(clone)
 }
 
 // NewRepository get Repository client
 // Use the internal meta and secret to generate the client, please assign in advance.
 func (p *PluginClient) NewRepository() ClientRepository {
-	return newRepository(p, p.meta, p.secret)
+	return newRepository(p)
 }
 
 // Artifact get Artifact client
 func (p *PluginClient) Artifact(meta Meta, secret corev1.Secret) ClientArtifact {
-	return newArtifact(p, meta, secret)
+	clone := p.Clone().WithMeta(meta).WithSecret(secret)
+
+	return newArtifact(clone)
 }
 
 // NewArtifact get Artifact client
 // Use the internal meta and secret to generate the client, please assign in advance.
 func (p *PluginClient) NewArtifact() ClientArtifact {
-	return newArtifact(p, p.meta, p.secret)
+	return newArtifact(p)
 }
 
 // GitBranch get branch client
 func (p *PluginClient) GitBranch(meta Meta, secret corev1.Secret) ClientGitBranch {
-	return newGitBranch(p, meta, secret)
+	clone := p.Clone().WithMeta(meta).WithSecret(secret)
+
+	return newGitBranch(clone)
 }
 
 // NewGitBranch get branch client
 // Use the internal meta and secret to generate the client, please assign in advance.
 func (p *PluginClient) NewGitBranch() ClientGitBranch {
-	return newGitBranch(p, p.meta, p.secret)
+	return newGitBranch(p)
 }
 
 // GitContent get content client
 func (p *PluginClient) GitContent(meta Meta, secret corev1.Secret) ClientGitContent {
-	return newGitContent(p, meta, secret)
+	clone := p.Clone().WithMeta(meta).WithSecret(secret)
+
+	return newGitContent(clone)
 }
 
 // NewGitContent get content client
 // Use the internal meta and secret to generate the client, please assign in advance.
 func (p *PluginClient) NewGitContent() ClientGitContent {
-	return newGitContent(p, p.meta, p.secret)
+	return newGitContent(p)
 }
 
 // GitPullRequest get pr client
 func (p *PluginClient) GitPullRequest(meta Meta, secret corev1.Secret) GitPullRequestCRUClient {
-	return newGitPullRequest(p, meta, secret)
+	clone := p.Clone().WithMeta(meta).WithSecret(secret)
+
+	return newGitPullRequest(clone)
 }
 
 // NewGitPullRequest get pr client
 // Use the internal meta and secret to generate the client, please assign in advance.
 func (p *PluginClient) NewGitPullRequest() GitPullRequestCRUClient {
-	return newGitPullRequest(p, p.meta, p.secret)
+	return newGitPullRequest(p)
 }
 
 // GitCommit get pr client
 func (p *PluginClient) GitCommit(meta Meta, secret corev1.Secret) ClientGitCommit {
-	return newGitCommit(p, meta, secret)
+	clone := p.Clone().WithMeta(meta).WithSecret(secret)
+
+	return newGitCommit(clone)
 }
 
 // NewGitCommit get pr client
 // Use the internal meta and secret to generate the client, please assign in advance.
 func (p *PluginClient) NewGitCommit() ClientGitCommit {
-	return newGitCommit(p, p.meta, p.secret)
+	return newGitCommit(p)
 }
 
 // GitRepository get repo client
 func (p *PluginClient) GitRepository(meta Meta, secret corev1.Secret) ClientGitRepository {
-	return newGitRepository(p, meta, secret)
+	clone := p.Clone().WithMeta(meta).WithSecret(secret)
+
+	return newGitRepository(clone)
 }
 
 // NewGitRepository get repo client
 // Use the internal meta and secret to generate the client, please assign in advance.
 func (p *PluginClient) NewGitRepository() ClientGitRepository {
-	return newGitRepository(p, p.meta, p.secret)
+	return newGitRepository(p)
 }
 
 // GitRepositoryFileTree get repo file tree client
 func (p *PluginClient) GitRepositoryFileTree(meta Meta, secret corev1.Secret) ClientGitRepositoryFileTree {
-	return newGitRepositoryFileTree(p, meta, secret)
+	clone := p.Clone().WithMeta(meta).WithSecret(secret)
+
+	return newGitRepositoryFileTree(clone)
 }
 
 // NewGitRepositoryFileTree get repo file tree client
 // Use the internal meta and secret to generate the client, please assign in advance.
 func (p *PluginClient) NewGitRepositoryFileTree() ClientGitRepositoryFileTree {
-	return newGitRepositoryFileTree(p, p.meta, p.secret)
+	return newGitRepositoryFileTree(p)
 }
 
 // GitCommitComment get commit comment client
 func (p *PluginClient) GitCommitComment(meta Meta, secret corev1.Secret) ClientGitCommitComment {
-	return newGitCommitComment(p, meta, secret)
+	clone := p.Clone().WithMeta(meta).WithSecret(secret)
+
+	return newGitCommitComment(clone)
 }
 
 // NewGitCommitComment get commit comment client
 // Use the internal meta and secret to generate the client, please assign in advance.
 func (p *PluginClient) NewGitCommitComment() ClientGitCommitComment {
-	return newGitCommitComment(p, p.meta, p.secret)
+	return newGitCommitComment(p)
 }
 
 // GitCommitStatus get commit comment client
 func (p *PluginClient) GitCommitStatus(meta Meta, secret corev1.Secret) ClientGitCommitStatus {
-	return newGitCommitStatus(p, meta, secret)
+	clone := p.Clone().WithMeta(meta).WithSecret(secret)
+
+	return newGitCommitStatus(clone)
 }
 
 // NewGitCommitStatus get commit comment client
 // Use the internal meta and secret to generate the client, please assign in advance.
 func (p *PluginClient) NewGitCommitStatus() ClientGitCommitStatus {
-	return newGitCommitStatus(p, p.meta, p.secret)
+	return newGitCommitStatus(p)
 }
 
 // CodeQuality get code quality client
 func (p *PluginClient) CodeQuality(meta Meta, secret corev1.Secret) ClientCodeQuality {
-	return newCodeQuality(p, meta, secret)
+	clone := p.Clone().WithMeta(meta).WithSecret(secret)
+
+	return newCodeQuality(clone)
 }
 
 // NewCodeQuality get code quality client
 // Use the internal meta and secret to generate the client, please assign in advance.
 func (p *PluginClient) NewCodeQuality() ClientCodeQuality {
-	return newCodeQuality(p, p.meta, p.secret)
+	return newCodeQuality(p)
 }
 
 // BlobStore get blob store client
 func (p *PluginClient) BlobStore(meta Meta, secret corev1.Secret) ClientBlobStore {
-	return newBlobStore(p, meta, secret)
+	clone := p.Clone().WithMeta(meta).WithSecret(secret)
+
+	return newBlobStore(clone)
 }
 
 // NewBlobStore get blob store client
 // Use the internal meta and secret to generate the client, please assign in advance.
 func (p *PluginClient) NewBlobStore() ClientBlobStore {
-	return newBlobStore(p, p.meta, p.secret)
+	return newBlobStore(p)
 }
 
 // GitRepositoryTag get repository tag client
 func (p *PluginClient) GitRepositoryTag(meta Meta, secret corev1.Secret) ClientGitRepositoryTag {
-	return newGitRepositoryTag(p, meta, secret)
+	clone := p.Clone().WithMeta(meta).WithSecret(secret)
+
+	return newGitRepositoryTag(clone)
 }
 
 // NewGitRepositoryTag get repository tag client
 // Use the internal meta and secret to generate the client, please assign in advance.
 func (p *PluginClient) NewGitRepositoryTag() ClientGitRepositoryTag {
-	return newGitRepositoryTag(p, p.meta, p.secret)
+	return newGitRepositoryTag(p)
 }
 
 // TestPlan get test plan client
 func (p *PluginClient) TestPlan(meta Meta, secret corev1.Secret) ClientTestPlan {
-	return newTestPlan(p, meta, secret)
+	clone := p.Clone().WithMeta(meta).WithSecret(secret)
+
+	return newTestPlan(clone)
 }
 
 // TestCase get test case client
 func (p *PluginClient) TestCase(meta Meta, secret corev1.Secret) ClientTestCase {
-	return newTestCase(p, meta, secret)
+	clone := p.Clone().WithMeta(meta).WithSecret(secret)
+
+	return newTestCase(clone)
 }
 
 // TestModule get test module client
 func (p *PluginClient) TestModule(meta Meta, secret corev1.Secret) ClientTestModule {
-	return newTestModule(p, meta, secret)
+	clone := p.Clone().WithMeta(meta).WithSecret(secret)
+
+	return newTestModule(clone)
 }
 
 // TestCaseExecution get test case execution client
 func (p *PluginClient) TestCaseExecution(meta Meta, secret corev1.Secret) ClientTestCaseExecution {
-	return newTestCaseExecution(p, meta, secret)
+	clone := p.Clone().WithMeta(meta).WithSecret(secret)
+
+	return newTestCaseExecution(clone)
 }
 
 // NewToolService get tool service execution client
 func (p *PluginClient) NewToolService() ClientToolService {
-	return newToolService(p, p.meta, p.secret, p.ClassAddress)
+	return newToolService(p, p.ClassAddress)
 }

--- a/plugin/client/project.go
+++ b/plugin/client/project.go
@@ -20,7 +20,6 @@ import (
 	"context"
 
 	metav1alpha1 "github.com/katanomi/pkg/apis/meta/v1alpha1"
-	corev1 "k8s.io/api/core/v1"
 	duckv1 "knative.dev/pkg/apis/duck/v1"
 )
 
@@ -32,15 +31,11 @@ type ClientProject interface {
 
 type project struct {
 	client Client
-	meta   Meta
-	secret corev1.Secret
 }
 
-func newProject(client Client, meta Meta, secret corev1.Secret) ClientProject {
+func newProject(client Client) ClientProject {
 	return &project{
 		client: client,
-		meta:   meta,
-		secret: secret,
 	}
 }
 
@@ -48,7 +43,7 @@ func newProject(client Client, meta Meta, secret corev1.Secret) ClientProject {
 func (p *project) List(ctx context.Context, baseURL *duckv1.Addressable, options ...OptionFunc) (*metav1alpha1.ProjectList, error) {
 	list := &metav1alpha1.ProjectList{}
 
-	options = append(options, MetaOpts(p.meta), SecretOpts(p.secret), ResultOpts(list))
+	options = append(options, ResultOpts(list))
 	if err := p.client.Get(ctx, baseURL, "projects", options...); err != nil {
 		return nil, err
 	}
@@ -58,7 +53,7 @@ func (p *project) List(ctx context.Context, baseURL *duckv1.Addressable, options
 
 // Create create project using plugin
 func (p *project) Create(ctx context.Context, baseURL *duckv1.Addressable, project *metav1alpha1.Project, options ...OptionFunc) (*metav1alpha1.Project, error) {
-	options = append(options, MetaOpts(p.meta), SecretOpts(p.secret), BodyOpts(project))
+	options = append(options, BodyOpts(project))
 	if err := p.client.Post(ctx, baseURL, "projects", options...); err != nil {
 		return nil, err
 	}
@@ -69,7 +64,7 @@ func (p *project) Create(ctx context.Context, baseURL *duckv1.Addressable, proje
 // Get get project using plugin
 func (p *project) Get(ctx context.Context, baseURL *duckv1.Addressable, id string, options ...OptionFunc) (*metav1alpha1.Project, error) {
 	resp := &metav1alpha1.Project{}
-	options = append(options, MetaOpts(p.meta), SecretOpts(p.secret), ResultOpts(resp))
+	options = append(options, ResultOpts(resp))
 	if err := p.client.Get(ctx, baseURL, "projects/"+id, options...); err != nil {
 		return nil, err
 	}

--- a/plugin/client/repository.go
+++ b/plugin/client/repository.go
@@ -21,7 +21,6 @@ import (
 	"fmt"
 
 	metav1alpha1 "github.com/katanomi/pkg/apis/meta/v1alpha1"
-	corev1 "k8s.io/api/core/v1"
 	duckv1 "knative.dev/pkg/apis/duck/v1"
 )
 
@@ -31,15 +30,11 @@ type ClientRepository interface {
 
 type repository struct {
 	client Client
-	meta   Meta
-	secret corev1.Secret
 }
 
-func newRepository(client Client, meta Meta, secret corev1.Secret) ClientRepository {
+func newRepository(client Client) ClientRepository {
 	return &repository{
 		client: client,
-		meta:   meta,
-		secret: secret,
 	}
 }
 
@@ -48,7 +43,7 @@ func (p *repository) List(ctx context.Context, baseURL *duckv1.Addressable, proj
 	list := &metav1alpha1.RepositoryList{}
 
 	uri := fmt.Sprintf("projects/%s/repositories", project)
-	options = append(options, MetaOpts(p.meta), SecretOpts(p.secret), ResultOpts(list))
+	options = append(options, ResultOpts(list))
 	if err := p.client.Get(ctx, baseURL, uri, options...); err != nil {
 		return nil, err
 	}

--- a/plugin/client/testcase.go
+++ b/plugin/client/testcase.go
@@ -21,7 +21,6 @@ import (
 	"fmt"
 
 	metav1alpha1 "github.com/katanomi/pkg/apis/meta/v1alpha1"
-	corev1 "k8s.io/api/core/v1"
 	duckv1 "knative.dev/pkg/apis/duck/v1"
 )
 
@@ -33,15 +32,11 @@ type ClientTestCase interface {
 
 type testCase struct {
 	client Client
-	meta   Meta
-	secret corev1.Secret
 }
 
-func newTestCase(client Client, meta Meta, secret corev1.Secret) ClientTestCase {
+func newTestCase(client Client) ClientTestCase {
 	return &testCase{
 		client: client,
-		meta:   meta,
-		secret: secret,
 	}
 }
 
@@ -50,7 +45,7 @@ func (p *testCase) List(ctx context.Context, baseURL *duckv1.Addressable, params
 	list := &metav1alpha1.TestCaseList{}
 
 	uri := fmt.Sprintf("projects/%s/testplans/%s/testcases", params.Project, params.TestPlanID)
-	options = append(options, MetaOpts(p.meta), SecretOpts(p.secret), ResultOpts(list), QueryOpts(map[string]string{
+	options = append(options, ResultOpts(list), QueryOpts(map[string]string{
 		"buildID": params.BuildID,
 	}))
 	if err := p.client.Get(ctx, baseURL, uri, options...); err != nil {
@@ -64,7 +59,7 @@ func (p *testCase) Get(ctx context.Context, baseURL *duckv1.Addressable, params 
 	tc := &metav1alpha1.TestCase{}
 
 	uri := fmt.Sprintf("projects/%s/testplans/%s/testcases/%s", params.Project, params.TestPlanID, params.TestCaseID)
-	options = append(options, MetaOpts(p.meta), SecretOpts(p.secret), ResultOpts(tc), QueryOpts(map[string]string{
+	options = append(options, ResultOpts(tc), QueryOpts(map[string]string{
 		"buildID": params.BuildID,
 	}))
 	if err := p.client.Get(ctx, baseURL, uri, options...); err != nil {

--- a/plugin/client/testcaseexecution.go
+++ b/plugin/client/testcaseexecution.go
@@ -21,7 +21,6 @@ import (
 	"fmt"
 
 	metav1alpha1 "github.com/katanomi/pkg/apis/meta/v1alpha1"
-	corev1 "k8s.io/api/core/v1"
 	duckv1 "knative.dev/pkg/apis/duck/v1"
 )
 
@@ -41,15 +40,11 @@ type ClientTestCaseExecution interface {
 
 type testCaseExecution struct {
 	client Client
-	meta   Meta
-	secret corev1.Secret
 }
 
-func newTestCaseExecution(client Client, meta Meta, secret corev1.Secret) ClientTestCaseExecution {
+func newTestCaseExecution(client Client) ClientTestCaseExecution {
 	return &testCaseExecution{
 		client: client,
-		meta:   meta,
-		secret: secret,
 	}
 }
 
@@ -66,7 +61,7 @@ func (p *testCaseExecution) List(ctx context.Context,
 		params.TestPlanID,
 		params.TestCaseID,
 	)
-	options = append(options, MetaOpts(p.meta), SecretOpts(p.secret), ResultOpts(list), QueryOpts(map[string]string{
+	options = append(options, ResultOpts(list), QueryOpts(map[string]string{
 		"buildID": params.BuildID,
 	}))
 	if err := p.client.Get(ctx, baseURL, uri, options...); err != nil {
@@ -85,7 +80,7 @@ func (p *testCaseExecution) Create(ctx context.Context,
 
 	uri := fmt.Sprintf("projects/%s/testplans/%s/testcases/%s/executions", params.Project, params.TestPlanID,
 		params.TestCaseID)
-	options = append(options, MetaOpts(p.meta), SecretOpts(p.secret), BodyOpts(payload), ResultOpts(tc))
+	options = append(options, BodyOpts(payload), ResultOpts(tc))
 	if err := p.client.Post(ctx, baseURL, uri, options...); err != nil {
 		return nil, err
 	}

--- a/plugin/client/testmodule.go
+++ b/plugin/client/testmodule.go
@@ -21,7 +21,6 @@ import (
 	"fmt"
 
 	metav1alpha1 "github.com/katanomi/pkg/apis/meta/v1alpha1"
-	corev1 "k8s.io/api/core/v1"
 	duckv1 "knative.dev/pkg/apis/duck/v1"
 )
 
@@ -32,15 +31,11 @@ type ClientTestModule interface {
 
 type testModule struct {
 	client Client
-	meta   Meta
-	secret corev1.Secret
 }
 
-func newTestModule(client Client, meta Meta, secret corev1.Secret) ClientTestModule {
+func newTestModule(client Client) ClientTestModule {
 	return &testModule{
 		client: client,
-		meta:   meta,
-		secret: secret,
 	}
 }
 
@@ -49,7 +44,7 @@ func (p *testModule) List(ctx context.Context, baseURL *duckv1.Addressable, para
 	list := &metav1alpha1.TestModuleList{}
 
 	uri := fmt.Sprintf("projects/%s/testplans/%s/testmodules", params.Project, params.TestPlanID)
-	options = append(options, MetaOpts(p.meta), SecretOpts(p.secret), ResultOpts(list))
+	options = append(options, ResultOpts(list))
 	if err := p.client.Get(ctx, baseURL, uri, options...); err != nil {
 		return nil, err
 	}

--- a/plugin/client/testplan.go
+++ b/plugin/client/testplan.go
@@ -21,7 +21,6 @@ import (
 	"fmt"
 
 	metav1alpha1 "github.com/katanomi/pkg/apis/meta/v1alpha1"
-	corev1 "k8s.io/api/core/v1"
 	duckv1 "knative.dev/pkg/apis/duck/v1"
 )
 
@@ -39,15 +38,11 @@ type ClientTestPlan interface {
 
 type testPlan struct {
 	client Client
-	meta   Meta
-	secret corev1.Secret
 }
 
-func newTestPlan(client Client, meta Meta, secret corev1.Secret) ClientTestPlan {
+func newTestPlan(client Client) ClientTestPlan {
 	return &testPlan{
 		client: client,
-		meta:   meta,
-		secret: secret,
 	}
 }
 
@@ -61,7 +56,7 @@ func (p *testPlan) List(
 	list := &metav1alpha1.TestPlanList{}
 
 	uri := fmt.Sprintf("projects/%s/testplans", params.Project)
-	options = append(options, MetaOpts(p.meta), SecretOpts(p.secret), ResultOpts(list),
+	options = append(options, ResultOpts(list),
 		QueryOpts(map[string]string{
 			"name":    params.Search,
 			"buildID": params.BuildID,
@@ -77,7 +72,7 @@ func (p *testPlan) Get(ctx context.Context, baseURL *duckv1.Addressable, params 
 	tc := &metav1alpha1.TestPlan{}
 
 	uri := fmt.Sprintf("projects/%s/testplans/%s", params.Project, params.TestPlanID)
-	options = append(options, MetaOpts(p.meta), SecretOpts(p.secret), ResultOpts(tc), QueryOpts(map[string]string{
+	options = append(options, ResultOpts(tc), QueryOpts(map[string]string{
 		"buildID": params.BuildID,
 	}))
 	if err := p.client.Get(ctx, baseURL, uri, options...); err != nil {

--- a/plugin/client/tool_service.go
+++ b/plugin/client/tool_service.go
@@ -19,7 +19,6 @@ package client
 import (
 	"context"
 
-	corev1 "k8s.io/api/core/v1"
 	duckv1 "knative.dev/pkg/apis/duck/v1"
 )
 
@@ -30,28 +29,22 @@ type ClientToolService interface {
 
 type toolService struct {
 	client  Client
-	meta    Meta
-	secret  corev1.Secret
 	baseURL *duckv1.Addressable
 }
 
-func newToolService(client Client, meta Meta, secret corev1.Secret, baseURL *duckv1.Addressable) ClientToolService {
+func newToolService(client Client, baseURL *duckv1.Addressable) ClientToolService {
 	return &toolService{
 		client:  client,
-		meta:    meta,
-		secret:  secret,
 		baseURL: baseURL,
 	}
 }
 
 // CheckAlive to check if the tool service is alive
 func (p *toolService) CheckAlive(ctx context.Context, options ...OptionFunc) error {
-	options = append(options, MetaOpts(p.meta), SecretOpts(p.secret))
 	return p.client.Get(ctx, p.baseURL, "tools/liveness", options...)
 }
 
 // Initialize to initialize the tool service
 func (p *toolService) Initialize(ctx context.Context, options ...OptionFunc) error {
-	options = append(options, MetaOpts(p.meta), SecretOpts(p.secret))
 	return p.client.Get(ctx, p.baseURL, "tools/initialize", options...)
 }


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes
https://github.com/katanomi/pkg/pull/237 这个 pr 给 plugin client 增加了 meta、secret 字段，但是传递 meta、secret 的逻辑比较绕。

pr 对这部分做了简化，meta、secret 最终是给 plugin client 使用的，在内部处理就好，不需要传给后续的 client 了。


# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] [`spec` PR link](https://github.com/katanomi/spec) included
- [x] Follows the [commit message standard](https://github.com/katanomi/spec/blob/main/CONTRIBUTING.md#commits)
- [x] Meets the [contributing guidelines](https://github.com/katanomi/spec/blob/main/CONTRIBUTING.md) (including
  functionality, content, code)
- [x] Test cases with documentation and functionality works as expected using current and related github repos (MUST deploy and check)
- [x] Release notes block below has been filled in or deleted (only if no user facing changes)

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->