### PR TITLE
fix: validate for clusterfilter

### DIFF
--- a/apis/meta/v1alpha1/labels_annotations.go
+++ b/apis/meta/v1alpha1/labels_annotations.go
@@ -91,7 +91,9 @@ const (
 	// SecretTypeAnnotationKey annotation key for an existed secret with a different type
 	SecretTypeAnnotationKey = "katanomi.dev/secretType" //nolint:gosec
 	// ClusterNameAnnotationKey annotation key to store resource cluster name
-	ClusterNameAnnotationKey = "integrations.katanomi.dev/clusterName"
+	ClusterNameAnnotationKey = "katanomi.dev/clusterName"
+	// ClusterRefNamespaceAnnotationKey annotation key to store cluster reference namespace
+	ClusterRefNamespaceAnnotationKey = "katanomi.dev/clusterRefNamespace"
 	// TriggerNameAnnotationKey annotation key to store a friendly trigger name
 	TriggerNameAnnotationKey = "katanomi.dev/triggerName"
 	// SettingsConvertTypesKey annotation key to store the setting types need to be converted

--- a/apis/selection/v1alpha1/cluster_filter.go
+++ b/apis/selection/v1alpha1/cluster_filter.go
@@ -78,7 +78,9 @@ func (n ClusterFilterRule) Filter(uClusters []unstructured.Unstructured) []corev
 func (n *ClusterFilter) Validate(fld *field.Path) field.ErrorList {
 	errs := field.ErrorList{}
 
-	errs = append(errs, kvalidation.ValidateItemName(n.Namespace, false, field.NewPath("namespace"))...)
+	if n.Namespace != "" {
+		errs = append(errs, kvalidation.ValidateItemName(n.Namespace, false, fld.Child("namespace"))...)
+	}
 
 	bFilter := BaseFilter{
 		Selector: n.Selector,

--- a/apis/selection/v1alpha1/get_clusters.go
+++ b/apis/selection/v1alpha1/get_clusters.go
@@ -23,19 +23,14 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/dynamic"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	"github.com/katanomi/pkg/multicluster"
 	knamespace "github.com/katanomi/pkg/namespace"
 )
 
 var (
-	// ClusterRegistryGroupVersion is the group version for the cluster registry
-	ClusterRegistryGroupVersion = schema.GroupVersion{Group: "clusterregistry.k8s.io", Version: "v1alpha1"}
-	// ClusterGVR is the group version resource for the cluster registry
-	ClusterGVR = ClusterRegistryGroupVersion.WithResource("clusters")
-
 	// passAllClusterFilterRule used to pass all clusters
 	passAllClusterFilterRule = ClusterFilterRule{
 		Exact: map[string]string{},
@@ -93,7 +88,7 @@ func getClustersByLabelSelector(ctx context.Context, clt dynamic.Interface, labe
 		LabelSelector: metav1.FormatLabelSelector(labelSelector),
 	}
 	clusterList := &unstructured.UnstructuredList{}
-	dyclient := clt.Resource(ClusterGVR).Namespace(defaultNS)
+	dyclient := clt.Resource(multicluster.ClusterGVR).Namespace(defaultNS)
 	if clusterList, err = dyclient.List(ctx, opts); err != nil {
 		return
 	}
@@ -116,7 +111,7 @@ func getClustersByRefs(ctx context.Context, clt dynamic.Interface, refs []corev1
 		if ns == "" {
 			ns = defaultNS
 		}
-		dyclient := clt.Resource(ClusterGVR).Namespace(ns)
+		dyclient := clt.Resource(multicluster.ClusterGVR).Namespace(ns)
 		var cluster *unstructured.Unstructured
 		cluster, err = dyclient.Get(ctx, clusterRef.Name, metav1.GetOptions{})
 		err = client.IgnoreNotFound(err)

--- a/apis/selection/v1alpha1/get_clusters_test.go
+++ b/apis/selection/v1alpha1/get_clusters_test.go
@@ -24,6 +24,7 @@ import (
 	. "github.com/onsi/gomega"
 	"knative.dev/pkg/logging"
 
+	"github.com/katanomi/pkg/multicluster"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -51,11 +52,11 @@ var _ = Describe("Test.GetNamespacesBasedOnFilter", func() {
 		objs, err := LoadKubeResourcesAsUnstructured("testdata/clusterfilter.clusters.list.yaml")
 		Expect(err).Should(BeNil())
 		gvrToListKind := map[schema.GroupVersionResource]string{
-			ClusterGVR: "ClusterList",
+			multicluster.ClusterGVR: "ClusterList",
 		}
 		clt = dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme, gvrToListKind)
 		for i, obj := range objs {
-			clt.Resource(ClusterGVR).Namespace(obj.GetNamespace()).Create(ctx, &objs[i], metav1.CreateOptions{})
+			clt.Resource(multicluster.ClusterGVR).Namespace(obj.GetNamespace()).Create(ctx, &objs[i], metav1.CreateOptions{})
 		}
 	})
 

--- a/hack/boilerplate.go.txt
+++ b/hack/boilerplate.go.txt
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 The Katanomi Authors.
+Copyright 2023 The Katanomi Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/multicluster/clusterregistry_client.go
+++ b/multicluster/clusterregistry_client.go
@@ -69,6 +69,7 @@ func NewClusterRegistryClientOrDie(config *rest.Config) Interface {
 
 var ClusterRegistryGroupVersion = schema.GroupVersion{Group: "clusterregistry.k8s.io", Version: "v1alpha1"}
 var ClusterRegistryGVK = ClusterRegistryGroupVersion.WithKind("Cluster")
+var ClusterGVR = ClusterRegistryGroupVersion.WithResource("clusters")
 
 // GetConfig returns the configuration based on the Cluster
 func (m *ClusterRegistryClient) GetConfig(ctx context.Context, clusterRef *corev1.ObjectReference) (config *rest.Config, err error) {


### PR DESCRIPTION
Allows the namespace to be empty, indicating the namespace where the current resource is located.

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!--
Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)!

-->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] [`spec` PR link](https://github.com/katanomi/spec) included
  - https://github.com/katanomi/spec/pull/209
- [x] Follows the [commit message standard](https://github.com/katanomi/spec/blob/main/CONTRIBUTING.md#commits)
- [x] Meets the [contributing guidelines](https://github.com/katanomi/spec/blob/main/CONTRIBUTING.md) (including
  functionality, content, code)
- [x] Test cases with documentation and functionality works as expected using current and related github repos (MUST deploy and check)
- [x] Release notes block below has been filled in or deleted (only if no user facing changes)
