### PR TITLE
fix: avoid panic when commit properties is nil

### DIFF
--- a/apis/meta/v1alpha1/buildmetadata_funcs.go
+++ b/apis/meta/v1alpha1/buildmetadata_funcs.go
@@ -80,7 +80,7 @@ func (b *BuildGitCommitStatus) AssignByGitCommit(gitCommit *GitCommit) *BuildGit
 		b.WebURL = gitCommit.Spec.Address.URL.String()
 	}
 
-	if gitCommit.Spec.Properties.Raw != nil {
+	if gitCommit.Spec.Properties != nil && gitCommit.Spec.Properties.Raw != nil {
 		propertiesInfo := &CommitProperties{}
 		if err := json.Unmarshal(gitCommit.Spec.Properties.Raw, propertiesInfo); err == nil {
 			b.ShortID = propertiesInfo.ShortID


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes
* fix: avoid panic when commit properties is nil
<!--
Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)!

-->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [`spec` PR link](https://github.com/katanomi/spec) included
- [ ] Follows the [commit message standard](https://github.com/katanomi/spec/blob/main/CONTRIBUTING.md#commits)
- [ ] Meets the [contributing guidelines](https://github.com/katanomi/spec/blob/main/CONTRIBUTING.md) (including
  functionality, content, code)
- [ ] Test cases with documentation and functionality works as expected using current and related github repos (MUST deploy and check)
- [ ] Release notes block below has been filled in or deleted (only if no user facing changes)
