### PR TITLE
feat: add extededAddresses field to project struct.

### DIFF
--- a/apis/meta/v1alpha1/labels_annotations.go
+++ b/apis/meta/v1alpha1/labels_annotations.go
@@ -136,10 +136,10 @@ const (
 	// define custom PR revision prefixes
 	GitPRRevisionPrefixes = "gitPRRevisionPrefixes"
 
-	//  PYPISubResourceSuffixKey Add the corresponding suffix to the specified subResource which for pypi.
+	//  PYPISubResourceExtendedAddressSuffixKey Add the corresponding suffix to the specified subResource which for pypi.
 	// TODO: In the future, we need to adopt a better way to add
 	// an extended dependency repository address to the plug-in
-	PYPISubResourceSuffixKey = "pypiSubResourceSuffix"
+	PYPISubResourceExtendedAddressSuffixKey = "pypiSubResourceExtendedAddressSuffix"
 )
 
 // Attribute values for label source or manager

--- a/apis/meta/v1alpha1/labels_annotations.go
+++ b/apis/meta/v1alpha1/labels_annotations.go
@@ -135,6 +135,11 @@ const (
 	// GitPRRevisionPrefixes allows git related integrations
 	// define custom PR revision prefixes
 	GitPRRevisionPrefixes = "gitPRRevisionPrefixes"
+
+	//  PYPISubResourceSuffixKey Add the corresponding suffix to the specified subResource which for pypi.
+	// TODO: In the future, we need to adopt a better way to add
+	// an extended dependency repository address to the plug-in
+	PYPISubResourceSuffixKey = "pypiSubResourceSuffix"
 )
 
 // Attribute values for label source or manager

--- a/apis/meta/v1alpha1/project_types.go
+++ b/apis/meta/v1alpha1/project_types.go
@@ -147,6 +147,17 @@ const (
 	// TODO: add more subtypes
 )
 
+// ExtendAddressKey The name of the plugin extension url, only dependencyAddress is supported for now.
+// TODO: add more key for the plugin extension url.
+type ExtendAddressKey string
+
+const (
+	// DependencyAddressExtendKey describes the dependency repository address provided by the plugin
+	// If the tool has an independent dependency repository address,
+	// use this field to indicate, if not, take the same value as address
+	DependencyAddressExtendKey ExtendAddressKey = "dependencyAddress"
+)
+
 var ProjectGVK = GroupVersion.WithKind("Project")
 var ProjectListGVK = GroupVersion.WithKind("ProjectList")
 
@@ -172,11 +183,9 @@ type ProjectSpec struct {
 	// +optional
 	Access *duckv1.Addressable `json:"access,omitempty"`
 
-	// DependencyAddress stores the tool depends on the url the repository.
-	// If the tool has an independent dependency repository address,
-	// use this field to indicate, if not, take the same value as address
+	// ExtendAddress stores the tool extend url which has different repository than address.
 	// +optional
-	DependencyAddress *duckv1.Addressable `json:"dependencyAddress,omitempty"`
+	ExtendAddress map[ExtendAddressKey]*duckv1.Addressable `json:"extendAddress,omitempty"`
 
 	// project subtype
 	// +kubebuilder:default="Project"

--- a/apis/meta/v1alpha1/project_types.go
+++ b/apis/meta/v1alpha1/project_types.go
@@ -147,15 +147,15 @@ const (
 	// TODO: add more subtypes
 )
 
-// ExtendAddressKey The name of the plugin extension url, only dependencyAddress is supported for now.
+// ExtendedAddress The name of the plugin extension url, only dependencyAddress is supported for now.
 // TODO: add more key for the plugin extension url.
-type ExtendAddressKey string
+type ExtendedAddress string
 
 const (
-	// DependencyAddressExtendKey describes the dependency repository address provided by the plugin
+	// DependencyExtendedAddressKey describes the dependency repository address provided by the plugin
 	// If the tool has an independent dependency repository address,
 	// use this field to indicate, if not, take the same value as address
-	DependencyAddressExtendKey ExtendAddressKey = "dependencyAddress"
+	DependencyExtendedAddressKey ExtendedAddress = "dependency"
 )
 
 var ProjectGVK = GroupVersion.WithKind("Project")
@@ -183,9 +183,9 @@ type ProjectSpec struct {
 	// +optional
 	Access *duckv1.Addressable `json:"access,omitempty"`
 
-	// ExtendAddress stores the tool extend url which has different repository than address.
+	// ExtendedAddresses stores the tool extend url which has different repository than address.
 	// +optional
-	ExtendAddress map[ExtendAddressKey]*duckv1.Addressable `json:"extendAddress,omitempty"`
+	ExtendedAddresses map[ExtendedAddress]*duckv1.Addressable `json:"extendedAddresses,omitempty"`
 
 	// project subtype
 	// +kubebuilder:default="Project"

--- a/apis/meta/v1alpha1/project_types.go
+++ b/apis/meta/v1alpha1/project_types.go
@@ -172,6 +172,12 @@ type ProjectSpec struct {
 	// +optional
 	Access *duckv1.Addressable `json:"access,omitempty"`
 
+	// DependencyAddress stores the tool depends on the url the repository.
+	// If the tool has an independent dependency repository address,
+	// use this field to indicate, if not, take the same value as address
+	// +optional
+	DependencyAddress *duckv1.Addressable `json:"dependencyAddress,omitempty"`
+
 	// project subtype
 	// +kubebuilder:default="Project"
 	SubType ProjectSubType `json:"subType"`

--- a/plugin/client/interface.go
+++ b/plugin/client/interface.go
@@ -80,6 +80,10 @@ type ResourcePathFormatter interface {
 	GetResourcePathFmt() map[metav1alpha1.ResourcePathScene]string
 	// GetSubResourcePathFmt resource path format
 	GetSubResourcePathFmt() map[metav1alpha1.ResourcePathScene]string
+
+	// GetPYPIResourcePathFmt return a list of pypi resource fmt that can be used in get projects list api.
+	// TODO: we need remove this func after find better way to add suffix to pypi dependency url.
+	GetPYPIResourcePathFmt() map[metav1alpha1.ProjectSubType]string
 }
 
 // AuthChecker implements an authorization check method for plugins

--- a/plugin/client/interface.go
+++ b/plugin/client/interface.go
@@ -80,10 +80,6 @@ type ResourcePathFormatter interface {
 	GetResourcePathFmt() map[metav1alpha1.ResourcePathScene]string
 	// GetSubResourcePathFmt resource path format
 	GetSubResourcePathFmt() map[metav1alpha1.ResourcePathScene]string
-
-	// GetPYPIResourcePathFmt return a list of pypi resource fmt that can be used in get projects list api.
-	// TODO: we need remove this func after find better way to add suffix to pypi dependency url.
-	GetPYPIResourcePathFmt() map[metav1alpha1.ProjectSubType]string
 }
 
 // AuthChecker implements an authorization check method for plugins


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes
There are different links for different uses of tools, add dependencyAddress field in the project, and support dependent repository address.

update in spec is here:https://github.com/katanomi/spec/pull/226/files 

<!--
Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)!

-->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] [`spec` PR link](https://github.com/katanomi/spec) included
- [x] Follows the [commit message standard](https://github.com/katanomi/spec/blob/main/CONTRIBUTING.md#commits)
- [ ] Meets the [contributing guidelines](https://github.com/katanomi/spec/blob/main/CONTRIBUTING.md) (including
  functionality, content, code)
- [ ] Test cases with documentation and functionality works as expected using current and related github repos (MUST deploy and check)
- [ ] Release notes block below has been filled in or deleted (only if no user facing changes)

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->