### PR TITLE
fix error of IgnoreForbidden overwrite ClusterNames in context

### DIFF
--- a/multicluster/context.go
+++ b/multicluster/context.go
@@ -59,12 +59,12 @@ type ignoreForbiddenKey struct{}
 
 // WithIgnoreForbidden adds ignore forbidden flag to the context
 func WithIgnoreForbidden(ctx context.Context, ignoreForbidden bool) context.Context {
-	return context.WithValue(ctx, clusterNamesKey{}, ignoreForbidden)
+	return context.WithValue(ctx, ignoreForbiddenKey{}, ignoreForbidden)
 }
 
 // IgnoreForbidden return a ignore forbidden flag in context
 func IgnoreForbidden(ctx context.Context) bool {
-	val := ctx.Value(clusterNamesKey{})
+	val := ctx.Value(ignoreForbiddenKey{})
 	if val == nil {
 		return false
 	}


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

WithIgnoreForbidden will overwrite ClusterNames value in context

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [`spec` PR link](https://github.com/katanomi/spec) included
- [x] Follows the [commit message standard](https://github.com/katanomi/spec/blob/main/CONTRIBUTING.md#commits)
- [x] Meets the [contributing guidelines](https://github.com/katanomi/spec/blob/main/CONTRIBUTING.md) (including
  functionality, content, code)
- [ ] Test cases with documentation and functionality works as expected using current and related github repos (MUST deploy and check)
- [x] Release notes block below has been filled in or deleted (only if no user facing changes)

# Release Notes


```release-note
bug fix: WithIgnoreForbidden will overwrite ClusterNames value in context
```