### PR TITLE
 fix bugs that user could use invalid token to get user owned resource

### DIFF
--- a/user/filter_test.go
+++ b/user/filter_test.go
@@ -87,10 +87,10 @@ func TestUserOwnedResourcePermissionFilter(t *testing.T) {
 	mockClient := mockfakeclient.NewMockClient(mockCtl)
 	mockClient.EXPECT().Create(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
 		func(ctx context.Context, obj ctrlclient.Object, opts ...ctrlclient.CreateOption) error {
-
-			sub, ok := obj.(*authv1.SubjectAccessReview)
+			user := kclient.User(ctx)
+			sub, ok := obj.(*authv1.SelfSubjectAccessReview)
 			if ok {
-				if sub.Spec.User == "admin" {
+				if user.GetName() == "admin" {
 					sub.Status.Denied = false
 					sub.Status.Allowed = true
 					return nil


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

 fix bugs that user could use invalid token (unauthorized) to get user owned resource

If user provide a valid jwt token but unauthorized, the UserOwnedResourcePermissionFilter cannot reject it with 401.
So, change SubjectAccessReview to SelfSubjectAccessReview to deal with unauthorized token.


# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [`spec` PR link](https://github.com/katanomi/spec) included
- [x] Follows the [commit message standard](https://github.com/katanomi/spec/blob/main/CONTRIBUTING.md#commits)
- [x] Meets the [contributing guidelines](https://github.com/katanomi/spec/blob/main/CONTRIBUTING.md) (including
  functionality, content, code)
- [x] Test cases with documentation and functionality works as expected using current and related github repos (MUST deploy and check)
- [x] Release notes block below has been filled in or deleted (only if no user facing changes)

# Release Notes

```release-note
bug fixes:  fix bugs that user could use invalid token to get user owned resource
```
