### PR TITLE
added HttpClientOptionFunc for NewHTTPClient method (#456)

### DIFF
--- a/client/defaults_test.go
+++ b/client/defaults_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package client
 
 import (
+	"net/http"
 	"os"
 	"testing"
 	"time"
@@ -40,4 +41,14 @@ func TestNewDefaultClientWithDefaultTimeOut(t *testing.T) {
 	client := NewHTTPClient()
 
 	g.Expect(client.Timeout).To(Equal(30 * time.Second))
+}
+
+func TestHttpClientOptionFunc(t *testing.T) {
+	g := NewGomegaWithT(t)
+	option := InsecureSkipVerifyOption
+
+	client := NewHTTPClient(option)
+
+	g.Expect(client.Timeout).To(Equal(30 * time.Second))
+	g.Expect(client.Transport.(*http.Transport).TLSClientConfig.InsecureSkipVerify).To(Equal(true))
 }


### PR DESCRIPTION
* added HttpClientOptionFunc for NewHTTPClient method

clean imports

* added testcase for NewHTTPClient

* impl HttpClientOption InsecureSkipVerifyOption

* added notes for InsecureSkipVerifyOption

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!--
Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)!

-->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [`spec` PR link](https://github.com/katanomi/spec) included
- [ ] Follows the [commit message standard](https://github.com/katanomi/spec/blob/main/CONTRIBUTING.md#commits)
- [ ] Meets the [contributing guidelines](https://github.com/katanomi/spec/blob/main/CONTRIBUTING.md) (including
  functionality, content, code)
- [ ] Test cases with documentation and functionality works as expected using current and related github repos (MUST deploy and check)
- [ ] Release notes block below has been filled in or deleted (only if no user facing changes)

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->