### PR TITLE
fix: check pr properties nil.

### DIFF
--- a/apis/meta/v1alpha1/buildmetadata_funcs.go
+++ b/apis/meta/v1alpha1/buildmetadata_funcs.go
@@ -107,7 +107,7 @@ func (b *BuildGitPullRequestStatus) AssignByGitPullRequest(gitPullRequest *GitPu
 	b.Target = gitPullRequest.Spec.Target.Name
 	b.Source = gitPullRequest.Spec.Source.Name
 	b.AuthorEmail = gitPullRequest.Spec.Author.Email
-	if gitPullRequest.Spec.Properties.Raw != nil {
+	if gitPullRequest.Spec.Properties != nil && gitPullRequest.Spec.Properties.Raw != nil {
 		var content map[string]string
 		json.Unmarshal(gitPullRequest.Spec.Properties.Raw, &content)
 		b.WebURL = content["webURL"]


### PR DESCRIPTION
# Changes

fix: check pr properties nil.

when plugin response not set properties, there will panic.

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [`spec` PR link](https://github.com/katanomi/spec) included
- [ ] Follows the [commit message standard](https://github.com/katanomi/spec/blob/main/CONTRIBUTING.md#commits)
- [ ] Meets the [contributing guidelines](https://github.com/katanomi/spec/blob/main/CONTRIBUTING.md) (including
  functionality, content, code)
- [ ] Test cases with documentation and functionality works as expected using current and related github repos (MUST deploy and check)
- [ ] Release notes block below has been filled in or deleted (only if no user facing changes)

