### PR TITLE
fix: add hostname tls ingnore for swr.

### DIFF
--- a/registry/helper.go
+++ b/registry/helper.go
@@ -142,8 +142,10 @@ func TryProtocolsWithRegistryURL(ctx context.Context, registry string, allowInse
 		}
 
 		caErr := errors.Unwrap(err)
-		_, ok := caErr.(x509.CertificateInvalidError)
-		if ok && allowInsecure {
+		_, isCertificateInvalidError := caErr.(x509.CertificateInvalidError)
+		_, isHostnameError := caErr.(x509.HostnameError)
+
+		if (isCertificateInvalidError || isHostnameError) && allowInsecure {
 			log.Debugw("Ignored invalid certificate", "protocol", proto, "registry", registry, "error", err)
 			return url, nil
 		}


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes
Add the ignore of hostname type certificate in registry

<!--
Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)!

-->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [`spec` PR link](https://github.com/katanomi/spec) included
- [x] Follows the [commit message standard](https://github.com/katanomi/spec/blob/main/CONTRIBUTING.md#commits)
- [ ] Meets the [contributing guidelines](https://github.com/katanomi/spec/blob/main/CONTRIBUTING.md) (including
  functionality, content, code)
- [ ] Test cases with documentation and functionality works as expected using current and related github repos (MUST deploy and check)
- [ ] Release notes block below has been filled in or deleted (only if no user facing changes)

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->