### PR TITLE
fix: webhook for resource name

### DIFF
--- a/apis/validation/name_validation.go
+++ b/apis/validation/name_validation.go
@@ -36,10 +36,10 @@ const genericResourceNameErrMsg string = "a resource name must consist of lower 
 
 var genericResourceNameRegexp = regexp.MustCompile("^" + genericResourceNameFmt + "$")
 
-const resourceNameWithChineseFmt = "[-./\\sA-Za-z0-9_\\p{Han}]+"
+const resourceNameWithChineseFmt = "[A-Za-z0-9\\p{Han}][-./\\sA-Za-z0-9_\\p{Han}]*"
 const resourceNameWithChineseErrMsg string = "a resource name must consist of lower case alphanumeric characters, Chinese, '_' or '-' or '/' or '.' "
 
-var resourceNameWithChineseRegexp = regexp.MustCompile("^[^\\s]" + resourceNameWithChineseFmt + "$")
+var resourceNameWithChineseRegexp = regexp.MustCompile("^" + resourceNameWithChineseFmt + "$")
 
 // IsDNS1123UnderscoreLabel tests for a string that conforms to the definition of a label in
 // DNS (RFC 1123) but accepting underscores in the middle.

--- a/apis/validation/name_validation_test.go
+++ b/apis/validation/name_validation_test.go
@@ -227,6 +227,13 @@ func TestValidateResourceNameWithChinese(t *testing.T) {
 				g.Expect(errs).To(HaveLen(0))
 			},
 		},
+		"Valid name with single char n": {
+			ktesting.LoadObjectOrDie(g, "testdata/pod-1abc.yaml", &corev1.Pod{}, ktesting.SetName("n")),
+			nil,
+			func(g *WithT, errs field.ErrorList) {
+				g.Expect(errs).To(HaveLen(0))
+			},
+		},
 		"Valid name with space \"123 abc\"": {
 			ktesting.LoadObjectOrDie(g, "testdata/pod-1abc.yaml", &corev1.Pod{}, ktesting.SetName("1113 abc")),
 			nil,


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!--
Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)!

-->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [`spec` PR link](https://github.com/katanomi/spec) included
- [ ] Follows the [commit message standard](https://github.com/katanomi/spec/blob/main/CONTRIBUTING.md#commits)
- [ ] Meets the [contributing guidelines](https://github.com/katanomi/spec/blob/main/CONTRIBUTING.md) (including
  functionality, content, code)
- [ ] Test cases with documentation and functionality works as expected using current and related github repos (MUST deploy and check)
- [ ] Release notes block below has been filled in or deleted (only if no user facing changes)

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->