### PR TITLE
fix: define project access url empty.

### DIFF
--- a/apis/meta/v1alpha1/labels_annotations.go
+++ b/apis/meta/v1alpha1/labels_annotations.go
@@ -154,6 +154,9 @@ const (
 	// TODO: In the future, we need to adopt a better way to add
 	// an extended dependency repository address to the plug-in
 	PYPISubResourceExtendedAddressSuffixKey = "pypiSubResourceExtendedAddressSuffix"
+
+	// ProjectAccessURLEmpty this property should be defined when the tool cannot set the project access address.
+	ProjectAccessURLEmpty = "projectAccessURLEmpty"
 )
 
 // Attribute values for label source or manager


### PR DESCRIPTION

# Changes

add ProjectAccessURLEmpty

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [`spec` PR link](https://github.com/katanomi/spec) included
- [x] Follows the [commit message standard](https://github.com/katanomi/spec/blob/main/CONTRIBUTING.md#commits)
- [ ] Meets the [contributing guidelines](https://github.com/katanomi/spec/blob/main/CONTRIBUTING.md) (including
  functionality, content, code)
- [ ] Test cases with documentation and functionality works as expected using current and related github repos (MUST deploy and check)
- [x] Release notes block below has been filled in or deleted (only if no user facing changes)

