### PR TITLE
shorten message length in event message

### DIFF
--- a/apis/meta/v1alpha1/condition.go
+++ b/apis/meta/v1alpha1/condition.go
@@ -19,6 +19,7 @@ package v1alpha1
 import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/utils/strings"
 	"knative.dev/pkg/apis"
 )
 
@@ -50,7 +51,8 @@ func SetConditionByErrorReason(conditionManager apis.ConditionManager, condition
 		if reason == "" {
 			reason = ReasonForError(err)
 		}
-		message := err.Error()
+		message := strings.ShortenString(err.Error(), MaxConditionMessageLength)
+
 		if old == nil || !old.IsFalse() || old.GetMessage() != message || old.GetReason() != reason {
 			conditionManager.MarkFalse(condition, reason, message)
 		}

--- a/apis/meta/v1alpha1/constant.go
+++ b/apis/meta/v1alpha1/constant.go
@@ -77,3 +77,8 @@ const (
 	// Error in sync report
 	CodeScanReportSyncErrorReason CodeScanReportSyncReason = "CodeScanSyncReportError"
 )
+
+const (
+	// MaxConditionMessageLength indicates max message field length in condition
+	MaxConditionMessageLength = 1000
+)

--- a/controllers/manager.go
+++ b/controllers/manager.go
@@ -1,0 +1,98 @@
+/*
+Copyright 2023 The Katanomi Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controllers
+
+import (
+	"fmt"
+
+	"k8s.io/utils/strings"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	cliengorecord "k8s.io/client-go/tools/record"
+	ctrl "sigs.k8s.io/controller-runtime"
+)
+
+const (
+	// MessageShortenLength default message shorten length in event
+	MessageShortenLength = 1000
+)
+
+// ControllerManager is just like sigs.k8s.io/controller-runtime.Manager
+// and decorate GetEventRecorderFor function to shorten message length
+type ControllerManager struct {
+	ctrl.Manager
+}
+
+// GetEventRecorderFor is just like sigs.k8s.io/controller-runtime.Manager.GetEventRecorderFor
+// but will return EventRecorder that could shorten message length
+func (m ControllerManager) GetEventRecorderFor(name string) cliengorecord.EventRecorder {
+	return &EventRecorder{
+		EventRecorder:     m.Manager.GetEventRecorderFor(name),
+		MessageShortenLen: MessageShortenLength,
+	}
+}
+
+// EventRecorder is just like k8s.io/client-go/tools/record.EventRecorder, but will shorten message length according to MessageShortenLen
+type EventRecorder struct {
+	cliengorecord.EventRecorder
+
+	// MessageShortenLen indicates max event message length, it will be shortened if length is more than MessageShortenLen
+	MessageShortenLen int
+}
+
+// Event is same as k8s.io/client-go/tools/record.EventRecorder.Event, just shorten message filed
+func (recorder *EventRecorder) Event(object runtime.Object, eventtype, reason, message string) {
+	recorder.EventRecorder.Event(object, eventtype, reason, strings.ShortenString(message, recorder.MessageShortenLen))
+}
+
+// Eventf is same as k8s.io/client-go/tools/record.EventRecorder.Eventf, just shorten args filed if the field type is Stringer or Error
+func (recorder *EventRecorder) Eventf(object runtime.Object, eventtype, reason, messageFmt string, args ...interface{}) {
+	shortens := recorder.shortenArgs(args...)
+	recorder.EventRecorder.Eventf(object, eventtype, reason, messageFmt, shortens...)
+}
+
+// AnnotatedEventf is same as k8s.io/client-go/tools/record.EventRecorder.Eventf, just shorten args filed if the field type is Stringer or Error
+func (recorder *EventRecorder) AnnotatedEventf(object runtime.Object, annotations map[string]string, eventtype, reason, messageFmt string, args ...interface{}) {
+	shortens := recorder.shortenArgs(args...)
+	recorder.EventRecorder.AnnotatedEventf(object, annotations, eventtype, reason, messageFmt, shortens...)
+}
+
+func (recorder *EventRecorder) shortenArgs(args ...interface{}) []interface{} {
+	shorten := make([]interface{}, 0, len(args))
+	for _, item := range args {
+		if arg, ok := item.(fmt.Stringer); ok {
+			shorten = append(shorten, strings.ShortenString(arg.String(), recorder.MessageShortenLen))
+			continue
+		}
+
+		if arg, ok := item.(string); ok {
+			shorten = append(shorten, strings.ShortenString(arg, recorder.MessageShortenLen))
+			continue
+		}
+
+		if arg, ok := item.(interface {
+			Error() string
+		}); ok {
+			shorten = append(shorten, strings.ShortenString(arg.Error(), recorder.MessageShortenLen))
+			continue
+		}
+
+		shorten = append(shorten, item)
+	}
+
+	return shorten
+}

--- a/controllers/manager_test.go
+++ b/controllers/manager_test.go
@@ -1,0 +1,173 @@
+/*
+Copyright 2023 The Katanomi Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controllers
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	cliengorecord "k8s.io/client-go/tools/record"
+
+	"github.com/golang/mock/gomock"
+	"github.com/katanomi/pkg/testing/mock/sigs.k8s.io/controller-runtime/pkg/manager"
+)
+
+func TestGetEventRecorderFor(t *testing.T) {
+	mockctl := gomock.NewController(t)
+	defer func() {
+		mockctl.Finish()
+	}()
+
+	mockManaer := manager.NewMockManager(mockctl)
+	mockManaer.EXPECT().GetEventRecorderFor(gomock.Any()).Return(cliengorecord.NewFakeRecorder(5)).Times(1)
+	var cm = ControllerManager{
+		Manager: mockManaer,
+	}
+
+	t.Run("it should return local EventRecorder", func(t *testing.T) {
+		recorder := cm.GetEventRecorderFor("Demo")
+		if _, ok := recorder.(*EventRecorder); !ok {
+			t.Errorf("should be *EventRecorder, but got %T", recorder)
+		}
+	})
+}
+
+func TestEventRecorder_Event(t *testing.T) {
+	fakeRecorder := cliengorecord.NewFakeRecorder(5)
+	rec := &EventRecorder{
+		EventRecorder:     fakeRecorder,
+		MessageShortenLen: 10,
+	}
+
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "demo", Namespace: "default"},
+	}
+	var data = []struct {
+		desc string
+		msg  string
+
+		expectedEvt string
+	}{
+		{
+			desc: "message is long than max length, it should be cut",
+			msg:  "this-is-long-message",
+
+			expectedEvt: "Warning PullImageFailed this-is-lo",
+		},
+		{
+			desc: "message is less than max length, it should be keep original string",
+			msg:  "message",
+
+			expectedEvt: "Warning PullImageFailed message",
+		},
+	}
+
+	for _, item := range data {
+		t.Run(item.desc, func(t *testing.T) {
+			rec.Event(pod, corev1.EventTypeWarning, "PullImageFailed", item.msg)
+
+			select {
+			case evt := <-fakeRecorder.Events:
+				{
+					diff := cmp.Diff(item.expectedEvt, evt)
+					if diff != "" {
+						t.Errorf("expected event is different with actual: %s", diff)
+					}
+				}
+			}
+		})
+	}
+}
+
+func TestEventRecorder_Eventf(t *testing.T) {
+	fakeRecorder := cliengorecord.NewFakeRecorder(5)
+	rec := &EventRecorder{
+		EventRecorder:     fakeRecorder,
+		MessageShortenLen: 10,
+	}
+
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "demo", Namespace: "default"},
+	}
+
+	var data = []struct {
+		desc   string
+		msgFmt string
+		args   []interface{}
+
+		expectedEvt string
+	}{
+		{
+			desc:   "arg is less than max length, it should keep original",
+			msgFmt: "arg1: %s, arg2: %s",
+			args: []interface{}{
+				"message1",
+				"message2",
+			},
+
+			expectedEvt: "Warning PullImageFailed arg1: message1, arg2: message2",
+		},
+
+		{
+			desc:   "message is long than max length and with other types, it should be cut",
+			msgFmt: "arg-long: %s, arg-short: %s, arg-error1: %s, arg-error2: %s, arg-int: %d, arg-bool: %t, arg-q: %q, arg-w: %w",
+			args: []interface{}{
+				"this-is-long-message",
+				"message",
+				fmt.Errorf("1-errors-created-by-fmt"),
+				fmt.Errorf("2-errors-created-by-fmt"),
+				1,
+				true,
+				"this-is-long-message-q",
+				fmt.Errorf("3-errors-created-by-fmt"),
+			},
+
+			expectedEvt: "Warning PullImageFailed arg-long: this-is-lo, arg-short: message, arg-error1: 1-errors-c, arg-error2: 2-errors-c, arg-int: 1, arg-bool: true, arg-q: \"this-is-lo\", arg-w: %!w(string=3-errors-c)",
+		},
+	}
+
+	for _, item := range data {
+		t.Run(item.desc, func(t *testing.T) {
+			rec.Eventf(pod, corev1.EventTypeWarning, "PullImageFailed", item.msgFmt, item.args...)
+
+			select {
+			case evt := <-fakeRecorder.Events:
+				{
+					diff := cmp.Diff(item.expectedEvt, evt)
+					if diff != "" {
+						t.Errorf("expected event is different with actual: %s", diff)
+					}
+				}
+			}
+
+			rec.AnnotatedEventf(pod, map[string]string{}, corev1.EventTypeWarning, "PullImageFailed", item.msgFmt, item.args...)
+			select {
+			case evt := <-fakeRecorder.Events:
+				{
+					diff := cmp.Diff(item.expectedEvt, evt)
+					if diff != "" {
+						t.Errorf("expected event is different with actual: %s", diff)
+					}
+				}
+			}
+		})
+	}
+}

--- a/sharedmain/app.go
+++ b/sharedmain/app.go
@@ -375,6 +375,9 @@ func (a *AppBuilder) Controllers(ctors ...controllers.SetupChecker) *AppBuilder 
 	if err != nil {
 		a.Logger.Fatalw("unable to start manager", "err", err)
 	}
+	a.Manager = controllers.ControllerManager{
+		Manager: a.Manager,
+	}
 	if err := a.Manager.AddHealthzCheck(healthzRoutePath, healthz.Ping); err != nil {
 		a.Logger.Fatalw("unable to set up health check", "err", err)
 	}


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

1. some event message come from error of tools, we cannot decide the content length , it will causes etcd db size increasing
2. shorten condition message length

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] https://github.com/katanomi/spec/pull/263
- [x] Follows the [commit message standard](https://github.com/katanomi/spec/blob/main/CONTRIBUTING.md#commits)
- [x] Meets the [contributing guidelines](https://github.com/katanomi/spec/blob/main/CONTRIBUTING.md) (including
  functionality, content, code)
- [x] Test cases with documentation and functionality works as expected using current and related github repos (MUST deploy and check)
- [x] Release notes block below has been filled in or deleted (only if no user facing changes)

# Release Notes

```release-note
Fix: fix long event message content breaks etcd
```