### PR TITLE
feat: Add pprof.enabled configuration flag for /debug/pprof APIs

### DIFF
--- a/config/config_suite_test.go
+++ b/config/config_suite_test.go
@@ -21,9 +21,20 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+
+	"knative.dev/pkg/logging"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+)
+
+var (
+	log, _ = logging.NewLogger("", "debug")
 )
 
 func TestConfig(t *testing.T) {
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "Config Suite")
 }
+
+var _ = BeforeSuite(func() {
+	log = zap.NewRaw(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)).Sugar()
+})

--- a/config/feature_flags.go
+++ b/config/feature_flags.go
@@ -57,6 +57,9 @@ const (
 
 	// IntegrationSyncPeriodKey indicates the configuration key for integration synchronization.
 	IntegrationSyncPeriodKey = "integration.syncPeriod"
+
+	// PprofEnabledKey indicates the configuration key of the /debug/pprof debugging api/
+	PprofEnabledKey = "pprof.enabled"
 )
 
 const (
@@ -101,6 +104,10 @@ const (
 
 	// DefaultIntegrationsSyncPeriod defines the default time interval of integration synchronization
 	DefaultIntegrationsSyncPeriod = "15m"
+
+	// DefaultPprofEnabled stores the default value "false" for the "pprof.enabled" /debug/pprof debugging api.
+	// If the corresponding key does not exist, the default value is returned.
+	DefaultPprofEnabled FeatureValue = "false"
 )
 
 // defaultFeatureValue defines the default value for the feature switch.
@@ -117,6 +124,7 @@ var defaultFeatureValue = map[string]FeatureValue{
 	PolicyCheckEnabledFeatureKey:           DefaultPolicyCheckEnabled,
 	ClusterIntegrationSyncPeriodKey:        DefaultClusterIntegrationSyncPeriod,
 	IntegrationSyncPeriodKey:               DefaultIntegrationsSyncPeriod,
+	PprofEnabledKey:                        DefaultPprofEnabled,
 }
 
 // FeatureFlags holds the features configurations

--- a/config/rest_filter.go
+++ b/config/rest_filter.go
@@ -1,0 +1,64 @@
+/*
+Copyright 2023 The Katanomi Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package config
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	restful "github.com/emicklei/go-restful/v3"
+	"github.com/katanomi/pkg/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"knative.dev/pkg/logging"
+)
+
+// ConfigKeyExpectedValueFunc is a helper function to check if configmap has expected value
+// If the value is not as expected, an error is expected to be returned
+type ConfigKeyExpectedValueFunc func(ctx context.Context, req *restful.Request, key string, value FeatureValue) (err error)
+
+// ConfigFilter adds a restful filter to manager to watch configmap and and custom validation
+// according a specific key value pair.
+func ConfigFilter(ctx context.Context, manager *Manager, configKey string, expectedKeyValueFunc ConfigKeyExpectedValueFunc) func(*restful.Request, *restful.Response, *restful.FilterChain) {
+	return func(req *restful.Request, res *restful.Response, chain *restful.FilterChain) {
+		featureValue := manager.GetFeatureFlag(configKey)
+		if err := expectedKeyValueFunc(ctx, req, configKey, featureValue); err != nil {
+			log := logging.FromContext(ctx)
+			log.Debugw("Error in ConfigFilter, will return", "err", err, "code", res.StatusCode())
+			errors.HandleError(req, res, err)
+			return
+		}
+		chain.ProcessFilter(req, res)
+	}
+}
+
+// ConfigFilterNotFoundWhenNotTrue is a helper ConfigKeyExpectedValue implementation that checks if the value is a boolean true
+// value, if not true will return a standard 404 not found error
+func ConfigFilterNotFoundWhenNotTrue(ctx context.Context, req *restful.Request, key string, value FeatureValue) (err error) {
+	if ok, _ := value.AsBool(); !ok {
+		return apierrors.NewGenericServerResponse(
+			http.StatusNotFound,
+			req.Request.Method,
+			errors.RESTAPIGroupResource,
+			req.Request.URL.String(),
+			fmt.Sprintf("%s Not Found", req.Request.URL.String()),
+			0,
+			false,
+		)
+	}
+	return nil
+}

--- a/config/rest_filter_test.go
+++ b/config/rest_filter_test.go
@@ -1,0 +1,128 @@
+/*
+Copyright 2023 The Katanomi Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package config
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+
+	restful "github.com/emicklei/go-restful/v3"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"knative.dev/pkg/logging"
+)
+
+var _ = Describe("ConfigFilter", func() {
+
+	var (
+		manager              *Manager
+		ctx                  context.Context
+		request              *restful.Request
+		response             *restful.Response
+		chain                *restful.FilterChain
+		recorder             *httptest.ResponseRecorder
+		key                  string
+		expectedKeyValueFunc ConfigKeyExpectedValueFunc
+	)
+
+	BeforeEach(func() {
+		ctx = context.Background()
+		ctx = logging.WithLogger(ctx, log)
+		req := &http.Request{
+			Header: map[string][]string{
+				restful.HEADER_AcceptEncoding: []string{restful.MIME_JSON},
+			},
+		}
+		testUrl, _ := url.Parse("http://test.example/some/path")
+		req.URL = testUrl
+		request = &restful.Request{Request: req}
+		recorder = httptest.NewRecorder()
+		response = &restful.Response{ResponseWriter: recorder}
+		response.SetRequestAccepts(restful.MIME_JSON)
+		chain = &restful.FilterChain{
+			Filters: []restful.FilterFunction{},
+			Target: func(req *restful.Request, resp *restful.Response) {
+				resp.WriteHeader(http.StatusOK)
+			},
+		}
+
+		manager = &Manager{Config: &Config{Data: map[string]string{"test": "test"}}}
+		key = "test"
+	})
+
+	JustBeforeEach(func() {
+		request.Request = request.Request.WithContext(ctx)
+
+		ConfigFilter(ctx, manager, key, expectedKeyValueFunc)(request, response, chain)
+	})
+
+	Context("Uses a \"test\" key with \"test\" value using some basic ConfigKeyExpectedValueFunc implementation", func() {
+		BeforeEach(func() {
+			expectedKeyValueFunc = func(ctx context.Context, req *restful.Request, key string, value FeatureValue) (err error) {
+				ok, err := value.AsBool()
+				if err != nil {
+					return err
+				} else if !ok {
+					return fmt.Errorf("value is not true: %v", value)
+				}
+				return nil
+			}
+		})
+		It("should have a internal error as status code with api error in response body", func() {
+			Expect(recorder.Code).To(Equal(http.StatusInternalServerError))
+			Expect(strings.TrimSpace(recorder.Body.String())).To(Equal(`{"metadata":{},"status":"Failure","message":"Internal error occurred: failed parsing feature flags config \"test\": strconv.ParseBool: parsing \"test\": invalid syntax","reason":"InternalError","details":{"causes":[{"message":"failed parsing feature flags config \"test\": strconv.ParseBool: parsing \"test\": invalid syntax"}]},"code":500}`))
+		})
+
+		Context("Uses a \"test\" key with \"true\" value using some basic ConfigKeyExpectedValueFunc implementation", func() {
+			BeforeEach(func() {
+				manager.Config.Data["test"] = "true"
+			})
+			It("should pass filter", func() {
+				Expect(recorder.Code).To(Equal(http.StatusOK))
+			})
+		})
+	})
+
+	Context("Uses ConfigFilterNotFoundWhenNotTrue with false value", func() {
+		BeforeEach(func() {
+			expectedKeyValueFunc = ConfigFilterNotFoundWhenNotTrue
+			manager.Config.Data["test"] = "false"
+		})
+
+		It("should have a not found error as status code with api error in response body", func() {
+			Expect(recorder.Code).To(Equal(http.StatusNotFound))
+			Expect(strings.TrimSpace(recorder.Body.String())).To(Equal(`{"metadata":{},"status":"Failure","message":"the server could not find the requested resource ( API.katanomi.dev http://test.example/some/path)","reason":"NotFound","details":{"name":"http://test.example/some/path","group":"katanomi.dev","kind":"API"},"code":404}`))
+		})
+
+	})
+
+	Context("Uses ConfigFilterNotFoundWhenNotTrue with true value", func() {
+		BeforeEach(func() {
+			expectedKeyValueFunc = ConfigFilterNotFoundWhenNotTrue
+			manager.Config.Data["test"] = "true"
+		})
+
+		It("should pass filter", func() {
+			Expect(recorder.Code).To(Equal(http.StatusOK))
+		})
+
+	})
+})

--- a/errors/errorhandling.go
+++ b/errors/errorhandling.go
@@ -31,6 +31,9 @@ import (
 // RESTClientGroupResource fake GroupResource to use errors api
 var RESTClientGroupResource = schema.GroupResource{Group: "katanomi.dev", Resource: "RESTfulClient"}
 
+// RESTAPIGroupResource fake GroupResource to use errors api
+var RESTAPIGroupResource = schema.GroupResource{Group: "katanomi.dev", Resource: "API"}
+
 // AsAPIError returns an error as a apimachinary api error
 func AsAPIError(err error) error {
 	reason := errors.ReasonForError(err)

--- a/plugin/plugin.go
+++ b/plugin/plugin.go
@@ -44,6 +44,9 @@ type plugin struct {
 
 type ShutdownFunc func() error
 
+// NewPlugin method never used. was supposed to initiate plugins
+// Deprecated: This plugin initializer has never been used and is not recommended
+// TODO: cleanup unnecessary code
 func NewPlugin() *plugin {
 	plugin := &plugin{
 		container: restful.NewContainer(),
@@ -78,7 +81,9 @@ func (p *plugin) prepare() {
 		}
 	}
 
-	p.container.Add(route.NewDefaultService())
+	// this plugin initialization process was never really used in production
+	// and is not recommended, so here we just give any context to the constructor
+	p.container.Add(route.NewDefaultService(context.Background()))
 
 	for _, each := range p.clients {
 		ws, err := route.NewService(each)

--- a/plugin/route/healthz.go
+++ b/plugin/route/healthz.go
@@ -17,6 +17,7 @@ limitations under the License.
 package route
 
 import (
+	"context"
 	"net/http"
 
 	"github.com/emicklei/go-restful/v3"
@@ -26,7 +27,7 @@ type healthz struct {
 }
 
 // NewHealthz basic health check service
-func NewHealthz() Route {
+func NewHealthz(ctx context.Context) Route {
 	return &healthz{}
 }
 

--- a/plugin/route/helper.go
+++ b/plugin/route/helper.go
@@ -35,3 +35,8 @@ func wrapperH(handler http.Handler) restful.RouteFunction {
 		handler.ServeHTTP(response.ResponseWriter, request.Request)
 	}
 }
+
+// NoOpFilter creates a default no operation filter
+func NoOpFilter(req *restful.Request, res *restful.Response, chain *restful.FilterChain) {
+	chain.ProcessFilter(req, res)
+}

--- a/plugin/route/route.go
+++ b/plugin/route/route.go
@@ -499,10 +499,10 @@ func NewService(c client.Interface, filters ...restful.FilterFunction) (*restful
 }
 
 // NewDefaultService default service included with metrics,pprof
-func NewDefaultService() *restful.WebService {
+func NewDefaultService(ctx context.Context) *restful.WebService {
 	routes := []Route{
-		NewSystem(),
-		NewHealthz(),
+		NewSystem(ctx),
+		NewHealthz(ctx),
 	}
 
 	ws := &restful.WebService{}

--- a/sharedmain/app.go
+++ b/sharedmain/app.go
@@ -607,7 +607,7 @@ func (a *AppBuilder) Run(startFuncs ...func(context.Context) error) error {
 	// adds a http server if there are any endpoints registered
 	if a.container != nil {
 		// adds profiling and health checks
-		a.container.Add(route.NewDefaultService())
+		a.container.Add(route.NewDefaultService(a.Context))
 
 		if len(a.container.RegisteredWebServices()) > 0 {
 			a.container.Add(route.NewDocService(a.container.RegisteredWebServices()...))


### PR DESCRIPTION
In order to disable access in production environments, a new filter was added to disable access when the configuration is set to any non true value. When changing the value the filter will pass and go tool pprof can be used directly

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

- Adds `pprof.enable` configuration flag check for `/debug/pprof` APIs on `RESTful` Services

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] [`spec` PR link](https://github.com/katanomi/spec) included
  -  https://github.com/katanomi/spec/pull/266
- [x] Follows the [commit message standard](https://github.com/katanomi/spec/blob/main/CONTRIBUTING.md#commits)
- [x] Meets the [contributing guidelines](https://github.com/katanomi/spec/blob/main/CONTRIBUTING.md) (including
  functionality, content, code)
- [x] Test cases with documentation and functionality works as expected using current and related github repos (MUST deploy and check)
- [x] Release notes block below has been filled in or deleted (only if no user facing changes)

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->