### PR TITLE
feat: add helper function to generate unique case name

### DIFF
--- a/testing/framework/case_builder.go
+++ b/testing/framework/case_builder.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/katanomi/pkg/testing"
 	. "github.com/katanomi/pkg/testing/framework/base"
 	. "github.com/onsi/ginkgo/v2"
 )
@@ -35,6 +36,8 @@ func newCase(name string, priority TestCasePriority) *CaseBuilder {
 					SugaredLogger: fmw.SugaredLogger.Named(name),
 				}
 			}),
+			// set the unique case name label
+			Labels: testing.Case(name),
 		},
 	}
 }

--- a/testing/label.go
+++ b/testing/label.go
@@ -1,0 +1,53 @@
+/*
+Copyright 2024 The Katanomi Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package testing
+
+import (
+	"fmt"
+	"regexp"
+
+	. "github.com/onsi/ginkgo/v2"
+)
+
+var caseNameReg = regexp.MustCompile(`{case:(\w+)}`)
+var unitTestCaseNameReg = regexp.MustCompile(`^Test(\w+)(/.*)*$`)
+
+// Case the unique case name label
+func Case(caseName string) Labels {
+	if caseName == "" {
+		return Labels{}
+	}
+	return Labels{fmt.Sprintf("{case:%s}", caseName)}
+}
+
+// GetCaseNames Resolve the case identifier from the testcase name in the junit report
+// For go test junit report, the case name may be started with `Test`, e.g: TestGetProject
+// For ginkgo test junit report, the case name may contain the {case:%s} string, e.g: [It] when xxxx [{case:GetProject}]
+func GetCaseNames(name string) []string {
+	parts := caseNameReg.FindAllStringSubmatch(name, -1)
+
+	if len(parts) == 0 {
+		parts = unitTestCaseNameReg.FindAllStringSubmatch(name, -1)
+	}
+
+	matchedNames := make([]string, 0, len(parts))
+	for _, item := range parts {
+		matchedNames = append(matchedNames, item[1])
+	}
+
+	return matchedNames
+}

--- a/testing/label_test.go
+++ b/testing/label_test.go
@@ -1,0 +1,109 @@
+/*
+Copyright 2024 The Katanomi Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package testing
+
+import (
+	"testing"
+
+	"github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestGetCaseName(t *testing.T) {
+	g := NewWithT(t)
+	tests := []struct {
+		name string
+		s    string
+		want []string
+	}{
+		{
+			name: "without case name",
+			s:    "test",
+			want: []string{},
+		},
+		{
+			name: "with case name",
+			s:    "{case:aaaa}",
+			want: []string{"aaaa"},
+		},
+		{
+			name: "case name contains underscore",
+			s:    "{case:aaaa_bbbb}",
+			want: []string{"aaaa_bbbb"},
+		},
+		{
+			name: "case name contains special characters",
+			s:    "{case:aaaa@bbbb}",
+			want: []string{},
+		},
+		{
+			name: "empty string",
+			s:    "",
+			want: []string{},
+		},
+		{
+			name: "Multiple case name",
+			s:    "{case:aaaa} {case:bbbb}",
+			want: []string{"aaaa", "bbbb"},
+		},
+		{
+			name: "go test case name",
+			s:    "TestAbc_eee",
+			want: []string{"Abc_eee"},
+		},
+		{
+			name: "go test case name with sub name",
+			s:    "TestAbc_eee/case1",
+			want: []string{"Abc_eee"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g.Expect(GetCaseNames(tt.s)).To(Equal(tt.want))
+		})
+	}
+}
+
+func TestCase(t *testing.T) {
+	g := NewWithT(t)
+	tests := []struct {
+		name     string
+		caseName string
+		want     ginkgo.Labels
+	}{
+		{
+			name:     "empty case name",
+			caseName: "",
+			want:     ginkgo.Labels{},
+		},
+		{
+			name:     "case name",
+			caseName: "abc",
+			want:     ginkgo.Labels{"{case:abc}"},
+		},
+		{
+			name:     "case name contains underscore",
+			caseName: "abc_eee",
+			want:     ginkgo.Labels{"{case:abc_eee}"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g.Expect(Case(tt.caseName)).To(Equal(tt.want))
+		})
+	}
+}


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

ginkgo 生成的 junit 报告中的 case 名称包含了用例的描述，所以要定义个特殊的格式来识别唯一名称。

现在代码中定义的格式是 `{case:the-real-unique-case-name}`，如 `{case:GetProject}`

```xml
<?xml version="1.0" encoding="UTF-8"?>
  <testsuites tests="9" disabled="0" errors="0" failures="0" time="0.000668">
      <testsuite name="integrations-e2e" package="/Users/xx/code/katanomi/integrations/test/e2e" tests="9" disabled="0" skipped="0" errors="0" failures="0" time="0.000668" timestamp="2024-02-28T19:21:23">
          <testcase name="[SynchronizedBeforeSuite]" classname="integrations-e2e" status="passed" time="0"></testcase>
          <testcase name="[It] [P1][ClusterIntegrationSyncPeriod] when Manual-Private-two-ns should change status from ready to not ready [{case:GetProject}, controller, integration]" classname="integrations-e2e" status="passed" time="0"></testcase>
          <testcase name="[SynchronizedAfterSuite]" classname="integrations-e2e" status="passed" time="0"></testcase>
      </testsuite>
  </testsuites>
```

# Changes

<!--
Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)!

-->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [`spec` PR link](https://github.com/katanomi/spec) included
- [ ] Follows the [commit message standard](https://github.com/katanomi/spec/blob/main/CONTRIBUTING.md#commits)
- [ ] Meets the [contributing guidelines](https://github.com/katanomi/spec/blob/main/CONTRIBUTING.md) (including
  functionality, content, code)
- [ ] Test cases with documentation and functionality works as expected using current and related github repos (MUST deploy and check)
- [ ] Release notes block below has been filled in or deleted (only if no user facing changes)

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->