### PR TITLE
add ExpectKubeResExistsAndEqualTo func to assert resources in cluster

### DIFF
--- a/testing/expect.go
+++ b/testing/expect.go
@@ -1,0 +1,128 @@
+/*
+Copyright 2024 The Katanomi Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package testing
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/onsi/gomega/format"
+
+	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/google/go-cmp/cmp"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/onsi/gomega"
+)
+
+// ExpectDiff will using github.com/google/go-cmp/cmp.Diff to compare two data
+// as default, it will not compare fields that have some undetermined value like uid, timestamp when compare kubernetes object
+// you can use diffCleanFuncs to change object in order to clean some fields that you don't want to compare
+// eg: clean status when compare
+//
+//	ExpectDiff(actual, expected, KubeObjectDiffClean, func(object ctrlclient.Object) {
+//		object.(*corev1.Pod).Status = corev1.PodStatus{} // do not compare Status
+//		return object
+//	}).Should(BeEmpty())
+func ExpectDiff(actual interface{}, expected interface{}, diffCleanFuncs ...func(object interface{}) interface{}) gomega.Assertion {
+	cleanFuncs := []func(object interface{}) interface{}{}
+	if len(diffCleanFuncs) == 0 {
+		cleanFuncs = append(cleanFuncs, KubeObjectDiffClean)
+	}
+	cleanFuncs = append(cleanFuncs, diffCleanFuncs...)
+
+	for _, cleanF := range cleanFuncs {
+		expected = cleanF(expected)
+		actual = cleanF(actual)
+	}
+
+	return gomega.Expect(cmp.Diff(expected, actual))
+}
+
+// KubeObjectDiffClean will clean these fields in order to clean when diff kubernetes objects
+//   - CreationTimestamp
+//   - ManagedFields
+//   - UID
+//   - ResourceVersion
+//   - Generation
+//   - SelfLink
+func KubeObjectDiffClean(object interface{}) interface{} {
+
+	k8sObject, ok := object.(ctrlclient.Object)
+	if !ok {
+		return object
+	}
+	k8sObject = k8sObject.DeepCopyObject().(ctrlclient.Object)
+
+	k8sObject.SetCreationTimestamp(metav1.NewTime(time.Time{}))
+	k8sObject.SetManagedFields(nil)
+	k8sObject.SetUID("")
+	k8sObject.SetResourceVersion("")
+	k8sObject.SetGeneration(0)
+	k8sObject.SetSelfLink("")
+
+	return k8sObject
+}
+
+// DiffEqualTo will use github.com/google/go-cmp/cmp.Diff to compare
+// you can use diffCleanFuncs to change object in order to clean some fields that you don't want to compare
+func DiffEqualTo(expected interface{}, diffCleanFuncs ...func(object interface{}) interface{}) gomega.OmegaMatcher {
+	return &DiffEqualMatcher{Expected: expected, DiffCleanFunc: diffCleanFuncs}
+}
+
+// DiffEqualMatcher will use github.com/google/go-cmp/cmp.Diff to compare
+// you can use diffCleanFuncs to change object in order to clean some fields that you don't want to compare
+type DiffEqualMatcher struct {
+	Expected      interface{}
+	DiffCleanFunc []func(object interface{}) interface{}
+
+	diff string
+}
+
+func (matcher *DiffEqualMatcher) Match(actual interface{}) (success bool, err error) {
+	if actual == nil && matcher.Expected == nil {
+		return false, fmt.Errorf("Both actual and expected must not be nil.")
+	}
+
+	cleanFuncs := []func(object interface{}) interface{}{}
+	if len(matcher.DiffCleanFunc) == 0 {
+		cleanFuncs = append(cleanFuncs, KubeObjectDiffClean)
+	}
+	cleanFuncs = append(cleanFuncs, matcher.DiffCleanFunc...)
+
+	for _, cleanF := range cleanFuncs {
+		matcher.Expected = cleanF(matcher.Expected)
+		actual = cleanF(actual)
+	}
+
+	diff := cmp.Diff(actual, matcher.Expected)
+	matcher.diff = diff
+	if diff == "" {
+		return true, nil
+	}
+
+	return false, nil
+}
+
+func (matcher *DiffEqualMatcher) FailureMessage(_ interface{}) (message string) {
+	return format.Message(matcher.diff, "to be equivalent to", "")
+}
+
+func (matcher *DiffEqualMatcher) NegatedFailureMessage(_ interface{}) (message string) {
+	return format.Message(matcher.diff, "not to be equivalent to", "")
+}

--- a/testing/expect_test.go
+++ b/testing/expect_test.go
@@ -1,0 +1,175 @@
+/*
+Copyright 2024 The Katanomi Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package testing
+
+import (
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var _ = Describe("DiffEqual", func() {
+	When("asserting that nil is equivalent to nil", func() {
+		It("should error", func() {
+			success, err := (&DiffEqualMatcher{Expected: nil}).Match(nil)
+
+			Expect(success).Should(BeFalse())
+			Expect(err).Should(HaveOccurred())
+		})
+	})
+
+	When("asserting on nil", func() {
+		It("should do the right thing", func() {
+			Expect("foo").ShouldNot(DiffEqualTo(nil))
+			Expect(nil).ShouldNot(DiffEqualTo(3))
+			Expect([]int{1, 2}).ShouldNot(DiffEqualTo(nil))
+		})
+	})
+
+	When("asserting on object", func() {
+		It("should do the right thing", func() {
+			Expect("foo").ShouldNot(DiffEqualTo(nil))
+			Expect(nil).ShouldNot(DiffEqualTo(3))
+			Expect([]int{1, 2}).ShouldNot(DiffEqualTo(nil))
+		})
+	})
+
+	When("asserting on kubernetes object", func() {
+		It("should do the right thing", func() {
+			pod := &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					ResourceVersion:   "11",
+					Generation:        1,
+					CreationTimestamp: metav1.NewTime(time.Now()),
+					Name:              "default",
+					Namespace:         "deault",
+				},
+				Data: map[string]string{
+					"a": "1",
+				},
+			}
+
+			Expect(pod).ShouldNot(DiffEqualTo(&corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "default",
+					Namespace: "deault",
+				},
+				Data: map[string]string{
+					"a": "12",
+				},
+			}))
+		})
+	})
+
+	When("asserting on kubernetes object with ignoreFuncs", func() {
+		It("should do the right thing", func() {
+			pod := &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					ResourceVersion:   "11",
+					Generation:        1,
+					CreationTimestamp: metav1.NewTime(time.Now()),
+					Name:              "default",
+					Namespace:         "deault",
+				},
+				Data: map[string]string{
+					"a": "1",
+				},
+			}
+
+			Expect(pod).Should(DiffEqualTo(&corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "foo-1",
+					Namespace: "foo",
+				},
+				Data: map[string]string{
+					"a": "1",
+				},
+			}, KubeObjectDiffClean, func(object interface{}) interface{} {
+				object.(*corev1.ConfigMap).ObjectMeta = metav1.ObjectMeta{}
+				return object
+			}))
+		})
+	})
+})
+
+var _ = Describe("ExpectDiff", func() {
+
+	When("asserting on kubernetes object with no ignore funcs", func() {
+		It("should do the right thing", func() {
+			pod := &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					ResourceVersion:   "11",
+					Generation:        1,
+					CreationTimestamp: metav1.NewTime(time.Now()),
+					Name:              "default",
+					Namespace:         "deault",
+				},
+				Data: map[string]string{
+					"a": "1",
+				},
+			}
+
+			actual := &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "default",
+					Namespace: "deault",
+				},
+				Data: map[string]string{
+					"a": "1",
+				},
+			}
+
+			ExpectDiff(pod, actual).Should(BeEmpty())
+		})
+	})
+
+	When("asserting on kubernetes object with ignoreFuncs", func() {
+		It("should do the right thing", func() {
+			pod := &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					ResourceVersion:   "11",
+					Generation:        1,
+					CreationTimestamp: metav1.NewTime(time.Now()),
+					Name:              "default",
+					Namespace:         "deault",
+				},
+				Data: map[string]string{
+					"a": "1",
+				},
+			}
+
+			expected := &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "foo-1",
+					Namespace: "foo",
+				},
+				Data: map[string]string{
+					"a": "1",
+				},
+			}
+
+			ExpectDiff(pod, expected, KubeObjectDiffClean, func(object interface{}) interface{} {
+				object.(*corev1.ConfigMap).ObjectMeta = metav1.ObjectMeta{}
+				return object
+			}).Should(BeEmpty())
+
+		})
+	})
+})

--- a/testing/framework/cluster/kubernetes.go
+++ b/testing/framework/cluster/kubernetes.go
@@ -1,0 +1,68 @@
+/*
+Copyright 2024 The Katanomi Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cluster
+
+import (
+	"fmt"
+
+	"github.com/katanomi/pkg/testing"
+	. "github.com/onsi/gomega"
+	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// ExpectKubeObject expect kubernetes resource exists by object.name and object.namespace, clean some fields in object and return gomega.Expect for this object.
+// the param object should contains Namespace and name.
+// you can use cleanFuncs to clean some fileds for object that load from kubernetes
+// eg.
+//
+//	ExpectKubeObject(&TestContext{Client: clt, Namespace: "default"}, &corev1.ConfigMap{
+//		ObjectMeta: metav1.ObjectMeta{
+//			Namespace: "default",
+//			Name:      "config-1",
+//		},
+//	}).Should(testing.DiffEqualTo(&corev1.ConfigMap{
+//		ObjectMeta: metav1.ObjectMeta{
+//			Namespace: "default",
+//			Name:      "config-1",
+//		},
+//		Data: map[string]string{
+//			"a": "a",
+//			"b": "b",
+//		},
+//	}))
+func ExpectKubeObject(ctx *TestContext, object ctrlclient.Object, cleanFuncs ...func(object interface{}) interface{}) Assertion {
+
+	gvk := object.GetObjectKind().GroupVersionKind()
+	err := ctx.Client.Get(ctx.Context, ctrlclient.ObjectKey{
+		Namespace: object.GetNamespace(),
+		Name:      object.GetName(),
+	}, object)
+
+	Expect(err).Should(BeNil())
+	object.GetObjectKind().SetGroupVersionKind(gvk)
+	fmt.Printf("===> %#v", object)
+	if len(cleanFuncs) == 0 {
+		cleanFuncs = []func(object interface{}) interface{}{
+			testing.KubeObjectDiffClean,
+		}
+	}
+
+	for _, clean := range cleanFuncs {
+		object = clean(object).(ctrlclient.Object)
+	}
+	return Expect(object)
+}

--- a/testing/framework/cluster/kubernetes_test.go
+++ b/testing/framework/cluster/kubernetes_test.go
@@ -1,0 +1,88 @@
+/*
+Copyright 2024 The Katanomi Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cluster
+
+import (
+	"github.com/katanomi/pkg/testing"
+	. "github.com/onsi/ginkgo/v2"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
+	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+var _ = Describe("ExpectKubeObject", func() {
+	var (
+		clt ctrlclient.Client
+	)
+
+	BeforeEach(func() {
+		clt = fakeclient.NewClientBuilder().WithScheme(clientgoscheme.Scheme).WithObjects(&corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "default",
+				Name:      "config-1",
+			},
+			Data: map[string]string{
+				"a": "a",
+				"b": "b",
+			},
+		}).Build()
+	})
+
+	When("clean func is nil", func() {
+		It("should comare succeed", func() {
+			ExpectKubeObject(&TestContext{Client: clt, Namespace: "default"}, &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "default",
+					Name:      "config-1",
+				},
+			}).Should(testing.DiffEqualTo(&corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "default",
+					Name:      "config-1",
+				},
+				Data: map[string]string{
+					"a": "a",
+					"b": "b",
+				},
+			}))
+		})
+	})
+
+	When("clean func is not nil", func() {
+		It("should comare succeed", func() {
+			ExpectKubeObject(&TestContext{Client: clt, Namespace: "default"}, &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "default",
+					Name:      "config-1",
+				},
+			}, testing.KubeObjectDiffClean, func(object interface{}) interface{} {
+				delete(object.(*corev1.ConfigMap).Data, "a")
+				return object
+			}).Should(testing.DiffEqualTo(&corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "default",
+					Name:      "config-1",
+				},
+				Data: map[string]string{
+					"b": "b",
+				},
+			}))
+		})
+	})
+})


### PR DESCRIPTION


<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes
add ExpectKubeResExistsAndEqualTo func to assert resources in cluster

it expects kubernetes resource exists and expects the resource is equal to `expectObject`

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [`spec` PR link](https://github.com/katanomi/spec) included
- [x] Follows the [commit message standard](https://github.com/katanomi/spec/blob/main/CONTRIBUTING.md#commits)
- [x] Meets the [contributing guidelines](https://github.com/katanomi/spec/blob/main/CONTRIBUTING.md) (including
  functionality, content, code)
- [x] Test cases with documentation and functionality works as expected using current and related github repos (MUST deploy and check)
- [x] Release notes block below has been filled in or deleted (only if no user facing changes)

# Release Notes

```release-note
NONE
```