### PR TITLE
fix: Correcting BuildMeta generation methods from Git Objects

### DIFF
--- a/apis/meta/v1alpha1/buildmetadata_funcs.go
+++ b/apis/meta/v1alpha1/buildmetadata_funcs.go
@@ -43,10 +43,15 @@ func (b *BuildGitBranchStatus) AssignByGitBranch(gitBranch *GitBranch) *BuildGit
 	if gitBranch.Spec.Protected != nil {
 		b.Protected = *gitBranch.Spec.Protected
 	}
+	b.WebURL = gitBranch.Spec.WebURL
 	if gitBranch.Spec.Properties != nil && gitBranch.Spec.Properties.Raw != nil {
 		var content map[string]string
 		json.Unmarshal(gitBranch.Spec.Properties.Raw, &content)
-		b.WebURL = content["webURL"]
+		// this is a fallback for when spec does not have the data
+		// or properties are overwritting this
+		if content["webURL"] != "" {
+			b.WebURL = content["webURL"]
+		}
 	}
 	return b
 }
@@ -80,6 +85,7 @@ func (b *BuildGitCommitStatus) AssignByGitCommit(gitCommit *GitCommit) *BuildGit
 	if gitCommit.Spec.Address != nil && gitCommit.Spec.Address.URL != nil {
 		b.WebURL = gitCommit.Spec.Address.URL.String()
 	}
+	b.PushedAt = &gitCommit.Spec.CreatedAt
 
 	if gitCommit.Spec.Properties != nil && gitCommit.Spec.Properties.Raw != nil {
 		propertiesInfo := &CommitProperties{}


### PR DESCRIPTION
Some objects are missing already existing attributes and relying exclusively on a properties structure

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!--
Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)!

-->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [`spec` PR link](https://github.com/katanomi/spec) included
- [ ] Follows the [commit message standard](https://github.com/katanomi/spec/blob/main/CONTRIBUTING.md#commits)
- [ ] Meets the [contributing guidelines](https://github.com/katanomi/spec/blob/main/CONTRIBUTING.md) (including
  functionality, content, code)
- [ ] Test cases with documentation and functionality works as expected using current and related github repos (MUST deploy and check)
- [ ] Release notes block below has been filled in or deleted (only if no user facing changes)

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->