### PR TITLE
Add LoadKubeResources in TestContext

### DIFF
--- a/testing/framework/cluster/kubernetes.go
+++ b/testing/framework/cluster/kubernetes.go
@@ -19,6 +19,8 @@ package cluster
 import (
 	"fmt"
 
+	"k8s.io/apimachinery/pkg/runtime"
+
 	"github.com/katanomi/pkg/testing"
 	. "github.com/onsi/gomega"
 	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
@@ -54,7 +56,6 @@ func ExpectKubeObject(ctx *TestContext, object ctrlclient.Object, cleanFuncs ...
 
 	Expect(err).Should(BeNil())
 	object.GetObjectKind().SetGroupVersionKind(gvk)
-	fmt.Printf("===> %#v", object)
 	if len(cleanFuncs) == 0 {
 		cleanFuncs = []func(object interface{}) interface{}{
 			testing.KubeObjectDiffClean,
@@ -65,4 +66,55 @@ func ExpectKubeObject(ctx *TestContext, object ctrlclient.Object, cleanFuncs ...
 		object = clean(object).(ctrlclient.Object)
 	}
 	return Expect(object)
+}
+
+// convertToSetNamespace will set object namespace according TestContext
+func convertToSetNamespace(namespace string) testing.ConvertRuntimeObjctToClientObjectFunc {
+	return func(object runtime.Object) (ctrlclient.Object, error) {
+		obj, ok := object.(ctrlclient.Object)
+		if !ok {
+			err := fmt.Errorf("Unsupported gvk: %s", object.GetObjectKind().GroupVersionKind())
+			return nil, err
+		}
+		if obj.GetNamespace() == "" {
+			obj.SetNamespace(namespace)
+		}
+		return obj, nil
+	}
+}
+
+// LoadKubeResources will load kubernetes resources from file
+// it will use client in ctx and set namespace as ctx.Namespace if namespace is empty in file
+// if you set namespace in file, it will just use it and ignore ctx.Namespace
+// you can set converts to change some extra fields before create in kubernetes
+// but you must pay attention to that when you set more than one converts: just one converts will be executed when match
+// if you set converts , you should set namespace to ctx.Namespace explicitly
+// eg.
+//
+//	LoadKubeResources(ctx, file)// load resource from file and apply to kubernetes with ctx.Namespace and ctx.Client
+//
+//	// load resource from file and execute convert if resource type is configmap before apply to kubernetes with ctx.Namespace and ctx.Client
+//
+//	LoadKubeResources(ctx, file,func(object runtime.Object) (ctrlclient.Object, error) {
+//		configmap, ok := object.(*corev1.ConfigMap)
+//		if !ok {
+//			return nil, fmt.Errorf("Unsupported gvk: %s", object.GetObjectKind().GroupVersionKind())
+//		}
+//		configmap.Namespace = "default-e2e"
+//		configmap.Annotations = map[string]string{
+//			"a": "1",
+//		}
+//		return configmap, nil
+//	})
+func LoadKubeResources(ctx *TestContext, file string, converts ...testing.ConvertRuntimeObjctToClientObjectFunc) (err error) {
+	converts = append(converts, convertToSetNamespace(ctx.Namespace))
+	return testing.LoadKubeResources(file, ctx.Client, converts...)
+}
+
+// MustLoadKubeResources similar with LoadKubeResources but panic if LoadKubeResources error
+func MustLoadKubeResources(ctx *TestContext, file string, converts ...testing.ConvertRuntimeObjctToClientObjectFunc) {
+	err := LoadKubeResources(ctx, file, converts...)
+	if err != nil {
+		panic(fmt.Sprintf("load yaml file failed, file path: %s, err: %s", file, err))
+	}
 }

--- a/testing/framework/cluster/kubernetes_test.go
+++ b/testing/framework/cluster/kubernetes_test.go
@@ -17,10 +17,15 @@ limitations under the License.
 package cluster
 
 import (
-	"github.com/katanomi/pkg/testing"
+	"testing"
+
+	"github.com/docker/distribution/context"
+	ktesting "github.com/katanomi/pkg/testing"
 	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -51,7 +56,7 @@ var _ = Describe("ExpectKubeObject", func() {
 					Namespace: "default",
 					Name:      "config-1",
 				},
-			}).Should(testing.DiffEqualTo(&corev1.ConfigMap{
+			}).Should(ktesting.DiffEqualTo(&corev1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: "default",
 					Name:      "config-1",
@@ -71,10 +76,10 @@ var _ = Describe("ExpectKubeObject", func() {
 					Namespace: "default",
 					Name:      "config-1",
 				},
-			}, testing.KubeObjectDiffClean, func(object interface{}) interface{} {
+			}, ktesting.KubeObjectDiffClean, func(object interface{}) interface{} {
 				delete(object.(*corev1.ConfigMap).Data, "a")
 				return object
-			}).Should(testing.DiffEqualTo(&corev1.ConfigMap{
+			}).Should(ktesting.DiffEqualTo(&corev1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: "default",
 					Name:      "config-1",
@@ -86,3 +91,80 @@ var _ = Describe("ExpectKubeObject", func() {
 		})
 	})
 })
+
+var _ = Describe("LoadKubeResources", func() {
+	var (
+		clt      ctrlclient.Client
+		file     string
+		converts []ktesting.ConvertRuntimeObjctToClientObjectFunc
+		err      error
+	)
+
+	BeforeEach(func() {
+		clt = fakeclient.NewClientBuilder().WithScheme(clientgoscheme.Scheme).Build()
+		converts = []ktesting.ConvertRuntimeObjctToClientObjectFunc{}
+	})
+	JustBeforeEach(func() {
+		err = LoadKubeResources(&TestContext{Namespace: "default-e2e", Client: clt}, file, converts...)
+	})
+
+	When("file is a kubernetes object that not set namespace", func() {
+		BeforeEach(func() {
+			file = "./testdata/LoadKubeResources.configmap.yaml"
+		})
+		It("should create the object in TestContext namespace", func() {
+			Expect(err).Should(BeNil())
+
+			configMap := &corev1.ConfigMap{}
+			err = clt.Get(context.Background(), ctrlclient.ObjectKey{Namespace: "default-e2e", Name: "default"}, configMap)
+			Expect(err).Should(BeNil())
+			Expect(configMap.Data["a"]).Should(BeEquivalentTo("1"))
+		})
+	})
+
+	When("file is a kubernetes object that set namespace", func() {
+		BeforeEach(func() {
+			file = "./testdata/LoadKubeResources.configmap-withns.yaml"
+		})
+		It("should create the object in namespace the specified in file", func() {
+			Expect(err).Should(BeNil())
+
+			configMap := &corev1.ConfigMap{}
+			err = clt.Get(context.Background(), ctrlclient.ObjectKey{Namespace: "default", Name: "default"}, configMap)
+			Expect(err).Should(BeNil())
+			Expect(configMap.Data["a"]).Should(BeEquivalentTo("1"))
+		})
+	})
+
+	When("use converts", func() {
+		BeforeEach(func() {
+			file = "./testdata/LoadKubeResources.configmap.yaml"
+			converts = append(converts, func(object runtime.Object) (ctrlclient.Object, error) {
+				configmap := object.(*corev1.ConfigMap)
+				configmap.Namespace = "default-e2e"
+				configmap.Annotations = map[string]string{
+					"a": "1",
+				}
+				return configmap, nil
+			})
+		})
+		It("should create the object according change by convertFunc", func() {
+			Expect(err).Should(BeNil())
+
+			configMap := &corev1.ConfigMap{}
+			err = clt.Get(context.Background(), ctrlclient.ObjectKey{Namespace: "default-e2e", Name: "default"}, configMap)
+			Expect(err).Should(BeNil())
+			Expect(configMap.Data["a"]).Should(BeEquivalentTo("1"))
+			Expect(configMap.Annotations["a"]).Should(BeEquivalentTo("1"))
+		})
+	})
+})
+
+func TestLoadKubeResources(t *testing.T) {
+	clt := fakeclient.NewClientBuilder().WithScheme(clientgoscheme.Scheme).Build()
+
+	g := NewGomegaWithT(t)
+	g.Expect(func() {
+		MustLoadKubeResources(&TestContext{Namespace: "default", Client: clt}, "./testdata/LoadKubeResources_invalid.yaml")
+	}).Should(Panic())
+}

--- a/testing/framework/cluster/testdata/LoadKubeResources.configmap-withns.yaml
+++ b/testing/framework/cluster/testdata/LoadKubeResources.configmap-withns.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: default
+  namespace: "default"
+data:
+  a: "1"

--- a/testing/framework/cluster/testdata/LoadKubeResources.configmap.yaml
+++ b/testing/framework/cluster/testdata/LoadKubeResources.configmap.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: default
+data:
+  a: "1"

--- a/testing/framework/cluster/testdata/LoadKubeResources.invalid.yaml
+++ b/testing/framework/cluster/testdata/LoadKubeResources.invalid.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+ ConfigMap
+metadata:
+  name: default
+data:
+   a: "1"


### PR DESCRIPTION


<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

1. when we load kube resource in TestContext, we usually want to creat object namespace according TestContext, but we cannot assume the namespace in resource file

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [`spec` PR link](https://github.com/katanomi/spec) included
- [x] Follows the [commit message standard](https://github.com/katanomi/spec/blob/main/CONTRIBUTING.md#commits)
- [x] Meets the [contributing guidelines](https://github.com/katanomi/spec/blob/main/CONTRIBUTING.md) (including
  functionality, content, code)
- [x] Test cases with documentation and functionality works as expected using current and related github repos (MUST deploy and check)
- [x] Release notes block below has been filled in or deleted (only if no user facing changes)

# Release Notes


```release-note
NONE
```
