### PR TITLE
feat: Add String() method to meta/v1alpha1/GitRepo structure

### DIFF
--- a/apis/meta/v1alpha1/gitbase_types.go
+++ b/apis/meta/v1alpha1/gitbase_types.go
@@ -57,6 +57,14 @@ func (in *GitRepo) ProjectID() string {
 	if in == nil {
 		return ""
 	}
+	return in.String()
+}
+
+// String prints the GitRepo data in a user friendly format
+// Example:
+//  For Project "abc" and repository "xyz" the output is "abc/xyz"
+// Compatible with %s format and other string printing methods
+func (in GitRepo) String() string {
 	return fmt.Sprintf("%s/%s", in.Project, in.Repository)
 }
 

--- a/apis/meta/v1alpha1/gitbase_types_test.go
+++ b/apis/meta/v1alpha1/gitbase_types_test.go
@@ -18,6 +18,9 @@ package v1alpha1
 
 import (
 	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 )
 
 func TestGitRepo_Validate(t *testing.T) {
@@ -92,3 +95,11 @@ func TestGitRepo_ProjectID(t *testing.T) {
 		})
 	}
 }
+
+var _ = DescribeTable("GitRepo.String", func(project, repository, expected string) {
+	repo := GitRepo{Project: project, Repository: repository}
+	Expect(repo.String()).To(Equal(expected), "for project %s and repository %s the expected value was %s", project, repository, expected)
+},
+	Entry("abc org using xyz repo", "abc", "xyz", "abc/xyz"),
+	Entry("root org using my-repo repo", "root", "my-repo", "root/my-repo"),
+)


### PR DESCRIPTION
Lots of places might depend on printing the project/repository format for logging or just for convenience. The ProjectID() implementation was changed to use the String() method as to make it uniform

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!--
Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)!

-->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [`spec` PR link](https://github.com/katanomi/spec) included
- [ ] Follows the [commit message standard](https://github.com/katanomi/spec/blob/main/CONTRIBUTING.md#commits)
- [ ] Meets the [contributing guidelines](https://github.com/katanomi/spec/blob/main/CONTRIBUTING.md) (including
  functionality, content, code)
- [ ] Test cases with documentation and functionality works as expected using current and related github repos (MUST deploy and check)
- [ ] Release notes block below has been filled in or deleted (only if no user facing changes)

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->