### PR TITLE
feat: Add IgnoreTypeMeta and IgnoreRawExtension cmp.Options

### DIFF
--- a/testing/assertions/diff.go
+++ b/testing/assertions/diff.go
@@ -30,6 +30,7 @@ import (
 	"github.com/onsi/gomega"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 )
 
 // DiffEqual will use github.com/google/go-cmp/cmp.Diff to compare
@@ -113,3 +114,9 @@ func IgnoreObjectMetaFields(fields ...string) cmp.Option {
 
 // DefaultIgnoreObjectMetaFields common fields to ignore in metav1.ObjectMeta using cmp.Diff method
 var DefaultIgnoreObjectMetaFields = []string{"CreationTimestamp", "DeletionTimestamp", "DeletionGracePeriodSeconds", "Finalizers", "UID", "Generation", "ManagedFields", "ResourceVersion", "SelfLink", "UID"}
+
+// IgnoreTypeMeta will ignore the fields in metav1.TypeMeta in a cmp.Diff comparison
+var IgnoreTypeMeta = cmpopts.IgnoreTypes(metav1.TypeMeta{})
+
+// IgnoreRawExtension will ignore the fields in runtime.RawExtension in a cmp.Diff comparison
+var IgnoreRawExtension = cmpopts.IgnoreTypes(runtime.RawExtension{})

--- a/testing/assertions/diff_test.go
+++ b/testing/assertions/diff_test.go
@@ -38,7 +38,7 @@ var _ = Describe("DiffEqual", func() {
 
 	When("asserting using clean function", func() {
 		It("should use diff clean function", func() {
-			data := map[string]string{"a":"b"}
+			data := map[string]string{"a": "b"}
 			matcher := &DiffEqualMatcher{Expected: data, DiffCleanFunc: []func(obj interface{}) interface{}{
 				func(obj interface{}) interface{} {
 					if dict, ok := obj.(map[string]string); ok {


### PR DESCRIPTION
In some test cases the data inside TypeMeta and RawExtension are not compulsory and can be ignored. Adding this variables here are for helping developers quickly reuse this cmp.Options and save time

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!--
Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)!

-->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [`spec` PR link](https://github.com/katanomi/spec) included
- [ ] Follows the [commit message standard](https://github.com/katanomi/spec/blob/main/CONTRIBUTING.md#commits)
- [ ] Meets the [contributing guidelines](https://github.com/katanomi/spec/blob/main/CONTRIBUTING.md) (including
  functionality, content, code)
- [ ] Test cases with documentation and functionality works as expected using current and related github repos (MUST deploy and check)
- [ ] Release notes block below has been filled in or deleted (only if no user facing changes)

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->