### PR TITLE
feat: add object list reporting to test cases

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -3,10 +3,11 @@ sonar.coverage.dtdVerification=false
 sonar.sourceEncoding=UTF-8
 
 sonar.sources=.
-sonar.exclusions=vendor/**,test/**,**/*_generated*go,**/generated.pb.go,**/*.md,bin/*,testbin/*,**/mock/**,go.mod,go.sum
+sonar.exclusions=vendor/**,test/**,**/*_generated*go,**/generated.pb.go,**/*.md,bin/*,testbin/*,**/mock/**,go.mod,go.sum,testing/**
 
 sonar.tests=.
 sonar.test.inclusions=**/*_test.go
+# sonar.test.exclusions=testing/mock/**
 
 sonar.go.tests.reportPaths=test.json
 sonar.go.coverage.reportPaths=cover.out

--- a/testing/framework/cluster/condition.go
+++ b/testing/framework/cluster/condition.go
@@ -183,10 +183,11 @@ func MustRollback(testCtx *TestContext, obj client.Object, opts ...client.Delete
 
 // WaitRollback Wait for the delete object behavior to complete
 func WaitRollback(testCtx *TestContext, obj client.Object) {
+	var err error
 	key := types.NamespacedName{Namespace: obj.GetNamespace(), Name: obj.GetName()}
 	Eventually(func(g Gomega) error {
-		err := testCtx.Client.Get(testCtx.Context, key, obj)
+		err = testCtx.Client.Get(testCtx.Context, key, obj)
 		g.Expect(errors.IsNotFound(err)).To(BeTrue())
 		return nil
-	}).WithPolling(time.Second).WithTimeout(time.Minute).Should(Succeed())
+	}).WithPolling(time.Second).WithTimeout(time.Minute).Should(Succeed(), "should delete object %s of kind %s but got err: %s", key, obj.GetObjectKind(), err)
 }

--- a/testing/framework/cluster/report.go
+++ b/testing/framework/cluster/report.go
@@ -1,0 +1,66 @@
+/*
+Copyright 2024 The Katanomi Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cluster
+
+import (
+	"fmt"
+
+	"github.com/katanomi/pkg/testing"
+	. "github.com/onsi/ginkgo/v2"
+	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// ReportObjectsLists will dump objects into Current Ginkgo Report when test case failed.
+// Example:
+//
+//	JustAfteEach(func() {
+//	  ReportObjectsLists(ctx, &corev1.ConfigMapList{}, &corev1.PodList{})
+//	})
+func ReportObjectsLists(ctx *TestContext, objects ...ctrlclient.ObjectList) {
+	for _, _item := range objects {
+		item := _item
+		ReportObjectListWithOptions(ctx, item)
+	}
+}
+
+// ReportObjectListWithOptions dumps the provided object list into the
+// current Ginkgo spec report if the test case has failed. It allows
+// passing client list options.
+// Example:
+//
+//	JustAfteEach(func() {
+//	  ReportObjectListWithOptions(ctx, &corev1.ConfigMapList{}, client.InNamespace(ctx.Namespace))
+//	})
+//
+// When using testing.ListByGVK:
+//
+//	JustAfteEach(func() {
+//	  ReportObjectListWithOptions(ctx, ListByGVK(schema.GroupVersionKind{
+//	    Group:   "katanomi.dev",
+//	    Version: "v1alpha1",
+//	    Kind:    "ClusterRuleList",
+//	  }), client.InNamespace(ctx.Namespace))
+//	})
+func ReportObjectListWithOptions(ctx *TestContext, list ctrlclient.ObjectList, opts ...ctrlclient.ListOption) {
+	name := fmt.Sprintf("%s", list.GetObjectKind().GroupVersionKind().String())
+	err := ctx.Client.List(ctx.Context, list, opts...)
+	if err != nil {
+		GinkgoWriter.Printf("list error: %s, list: %#v", err.Error(), list)
+		return
+	}
+	testing.AddReportEntryAsYaml(name, list)
+}

--- a/testing/report.go
+++ b/testing/report.go
@@ -1,0 +1,123 @@
+/*
+Copyright 2024 The Katanomi Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package testing
+
+import (
+	"encoding/base64"
+
+	. "github.com/onsi/ginkgo/v2"
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/yaml"
+)
+
+// AddReportEntriesAsYaml adds multiple report entries formatted as YAML
+// to the current SpecReport.
+// The Report entry visibility is set to ReportEntryVisibilityFailureOrVerbose.
+//
+// Example:
+//
+//	configMap := &corev1.ConfigMap{}
+//	service := &corev1.Service{}
+//	client.Get(ctx, key, configMap)
+//	client.Get(ctx, serviceKey, service)
+//	AddReportEntriesAsYaml("configuration", configMap, service)
+//
+// Note: Any pointer will be only printed as the final value when testing is completed
+// for current value provide the object as value:
+//
+//	AddReportEntriesAsYaml("previous-configuration", *configMap)
+func AddReportEntriesAsYaml(name string, objs ...interface{}) {
+	for _, obj := range objs {
+		AddReportEntryAsYaml(name, obj)
+	}
+}
+
+// AddReportEntryAsYaml marshals the given object as YAML and adds it
+// to the test report with the given name.
+// The Report entry visibility is set to ReportEntryVisibilityFailureOrVerbose.
+// Note: Any pointer will be only printed as the final value when testing is completed
+// for current value provide the object as value.
+//
+// Example:
+//
+//	configMap := &corev1.ConfigMap{}
+//	client.Get(ctx, key, configMap)
+//	AddReportEntryAsYaml("configuration", configMap)
+//
+// Note: Any pointer will be only printed as the final value when testing is completed
+// for current value provide the object as value:
+//
+//	AddReportEntryAsYaml("previous-configuration", *configMap)
+//
+// Will automatically redact secret data for corev1.Secret objects.
+func AddReportEntryAsYaml(name string, obj interface{}) {
+	obj = redactSecrets(obj)
+	if bts, err := yaml.Marshal(obj); err == nil {
+		AddReportEntry(name, ReportEntryVisibilityFailureOrVerbose, string(bts))
+	} else {
+		AddReportEntry(name, ReportEntryVisibilityFailureOrVerbose, obj)
+	}
+}
+
+const redactedString = "REDACTED"
+
+var redactedStringBase64 = base64.StdEncoding.EncodeToString([]byte(redactedString))
+
+// redactSecrets redacts sensitive fields in Kubernetes Secrets and SecretLists.
+// It returns a deep copy of the input with secret data replaced with
+// redacted values.
+func redactSecrets(obj interface{}) interface{} {
+	if obj == nil {
+		return nil
+	}
+	switch obj := obj.(type) {
+	case corev1.Secret:
+		objCopy := obj.DeepCopy()
+		objCopy.Data = redactSecretData(obj.Data)
+		return *objCopy
+	case *corev1.Secret:
+		objCopy := obj.DeepCopy()
+		objCopy.Data = redactSecretData(obj.Data)
+		return objCopy
+	case *corev1.SecretList:
+		objCopy := obj.DeepCopy()
+		for i := range objCopy.Items {
+			objCopy.Items[i] = redactSecrets(objCopy.Items[i]).(corev1.Secret)
+		}
+		return objCopy
+	case corev1.SecretList:
+		objCopy := obj.DeepCopy()
+		for i := range objCopy.Items {
+			objCopy.Items[i] = redactSecrets(objCopy.Items[i]).(corev1.Secret)
+		}
+		return *objCopy
+	default:
+		// fallthrough returns the original object
+		return obj
+	}
+}
+
+// redactSecretData redacts the sensitive data in a Secret's data map
+// by replacing the values with a redacted string. It returns a new
+// map with the redacted values.
+func redactSecretData(data map[string][]byte) map[string][]byte {
+	redactedData := map[string][]byte{}
+	for k := range data {
+		redactedData[k] = []byte(redactedStringBase64)
+	}
+	return redactedData
+}

--- a/testing/scheme.go
+++ b/testing/scheme.go
@@ -1,0 +1,30 @@
+/*
+Copyright 2024 The Katanomi Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package testing
+
+import (
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+// ListByGVK creates a new UnstructuredList initialized with the given GroupVersionKind.
+// Very useful for listing resources using only GroupVersionKind.
+func ListByGVK(gvk schema.GroupVersionKind) *unstructured.UnstructuredList {
+	list := &unstructured.UnstructuredList{}
+	list.SetGroupVersionKind(gvk)
+	return list
+}


### PR DESCRIPTION
Add the ability to specify ObjectLists that will be reported after a failed test case. This uses the existing ReportObjectsLists functionality to print the object lists.

To use this, call WithObjectListReport on a TestCaseBuilder with the desired ObjectList instances. Then these will be reported after any failing test case.

This can help debug issues by printing extra object state.

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!--
Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)!

-->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [`spec` PR link](https://github.com/katanomi/spec) included
- [ ] Follows the [commit message standard](https://github.com/katanomi/spec/blob/main/CONTRIBUTING.md#commits)
- [ ] Meets the [contributing guidelines](https://github.com/katanomi/spec/blob/main/CONTRIBUTING.md) (including
  functionality, content, code)
- [ ] Test cases with documentation and functionality works as expected using current and related github repos (MUST deploy and check)
- [ ] Release notes block below has been filled in or deleted (only if no user facing changes)

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->