### PR TITLE
feat: add namespace filtering for ReportObjectsLists

### DIFF
--- a/testing/framework/cluster/report.go
+++ b/testing/framework/cluster/report.go
@@ -31,9 +31,17 @@ import (
 //	  ReportObjectsLists(ctx, &corev1.ConfigMapList{}, &corev1.PodList{})
 //	})
 func ReportObjectsLists(ctx *TestContext, objects ...ctrlclient.ObjectList) {
+	// Adding InNamespace option will make test reports clear
+	// and will avoid extra noise from unrelated namespaces.
+	// For Cluster scoped resources this will have no effect and
+	// will return all resources in the cluster.
+	options := []ctrlclient.ListOption{}
+	if ctx.Namespace != "" {
+		options = append(options, ctrlclient.InNamespace(ctx.Namespace))
+	}
 	for _, _item := range objects {
 		item := _item
-		ReportObjectListWithOptions(ctx, item)
+		ReportObjectListWithOptions(ctx, item, options...)
 	}
 }
 


### PR DESCRIPTION
ReportObjectsLists now accepts a namespace option to filter results to the test context namespace.
This avoids noise from unrelated namespaces in test reports.

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!--
Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)!

-->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [`spec` PR link](https://github.com/katanomi/spec) included
- [ ] Follows the [commit message standard](https://github.com/katanomi/spec/blob/main/CONTRIBUTING.md#commits)
- [ ] Meets the [contributing guidelines](https://github.com/katanomi/spec/blob/main/CONTRIBUTING.md) (including
  functionality, content, code)
- [ ] Test cases with documentation and functionality works as expected using current and related github repos (MUST deploy and check)
- [ ] Release notes block below has been filled in or deleted (only if no user facing changes)

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->