### PR TITLE
feat: add lazy loading for feature cases

### DIFF
--- a/testing/framework/conformance/interface.go
+++ b/testing/framework/conformance/interface.go
@@ -16,6 +16,10 @@ limitations under the License.
 
 package conformance
 
+import (
+	. "github.com/onsi/ginkgo/v2"
+)
+
 // CaseSetFactory factory to create a case set
 type CaseSetFactory interface {
 	// New construct a new case set
@@ -31,6 +35,14 @@ type CaseSet interface {
 
 	// Optional mark the test as optional
 	Optional() CaseSet
+}
+
+// FeatureCaseLabeler is an interface that provides methods to
+// retrieve the labels associated with the feature case.
+//
+// Labels returns the labels associated with the feature case.
+type FeatureCaseLabeler interface {
+	Labels() Labels
 }
 
 // CaseLinker describe a interface to link test case to parent node

--- a/testing/framework/conformance/testpoint.go
+++ b/testing/framework/conformance/testpoint.go
@@ -38,7 +38,7 @@ type testPoint struct {
 	node *Node
 
 	// additionalAssertions each feature can have a custom assertion
-	additionalAssertions map[*featureCase]interface{}
+	additionalAssertions map[FeatureCaseLabeler]interface{}
 }
 
 // Labels returns all the labels for the test point
@@ -56,7 +56,7 @@ func (t *testPoint) Labels(ctx context.Context) Labels {
 func (t *testPoint) CheckExternalAssertion(args ...interface{}) {
 	contextLabel := CurrentSpecReport().Labels()
 	for feature, assertFunc := range t.additionalAssertions {
-		featureLabel := strings.Join(feature.node.Labels(), "#")
+		featureLabel := strings.Join(feature.Labels(), "#")
 		if !slices.Contains(contextLabel, featureLabel) {
 			continue
 		}
@@ -78,21 +78,22 @@ func (t *testPoint) CheckExternalAssertion(args ...interface{}) {
 }
 
 // Bind alias of AddAssertion
-func (t *testPoint) Bind(feature *featureCase) CustomAssertion {
+func (t *testPoint) Bind(feature FeatureCaseLabeler) CustomAssertion {
 	return AddAssertionFunc(func(f interface{}) *testPoint {
 		return t.AddAssertion(feature, f)
 	})
 }
 
 // AddAssertion add a custom assertion to the test point for a special feature
-func (t *testPoint) AddAssertion(feature *featureCase, assertFunc interface{}) *testPoint {
+// func (t *testPoint) AddAssertion(feature *featureCase, assertFunc interface{}) *testPoint {
+func (t *testPoint) AddAssertion(feature FeatureCaseLabeler, assertFunc interface{}) *testPoint {
 	// check assertFunc is a function
 	val := reflect.ValueOf(assertFunc)
 	if val.Kind() != reflect.Func || val.Type().NumIn() == 0 {
 		panic("assertFunc must be a function with at least one argument")
 	}
 	if t.additionalAssertions == nil {
-		t.additionalAssertions = make(map[*featureCase]interface{})
+		t.additionalAssertions = make(map[FeatureCaseLabeler]interface{})
 	}
 
 	t.additionalAssertions[feature] = assertFunc


### PR DESCRIPTION
This adds a new LazyFeatureCaseBuilder type that allows lazily loading feature cases only when needed. This avoids creating all feature cases upfront when defining the module.

A new GetFeatureCase method on moduleCase allows retrieving a lazy feature case builder by name.

The FeatureCaseBuilder interface is introduced with Labels() to get labels on feature cases. lazyFeatureCaseBuilder implements this to look up the real feature case labels only when Labels() is called.

additionalAssertions on testPoint now accepts FeatureCaseBuilder instead of *featureCase directly.

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

before the change:

<img width="949" alt="image" src="https://github.com/katanomi/pkg/assets/5045502/8449bc32-27b7-48c9-8077-2897d2bc76f5">


after:

<img width="966" alt="image" src="https://github.com/katanomi/pkg/assets/5045502/f4bb8f80-7b0f-4266-a0ca-de3f5e7623ac">


# Changes

<!--
Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)!

-->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [`spec` PR link](https://github.com/katanomi/spec) included
- [ ] Follows the [commit message standard](https://github.com/katanomi/spec/blob/main/CONTRIBUTING.md#commits)
- [ ] Meets the [contributing guidelines](https://github.com/katanomi/spec/blob/main/CONTRIBUTING.md) (including
  functionality, content, code)
- [ ] Test cases with documentation and functionality works as expected using current and related github repos (MUST deploy and check)
- [ ] Release notes block below has been filled in or deleted (only if no user facing changes)

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->