### PR TITLE
Make the taskRun sort stable

### DIFF
--- a/tekton/taskrun_sort_completion.go
+++ b/tekton/taskrun_sort_completion.go
@@ -17,6 +17,7 @@ limitations under the License.
 package tekton
 
 import (
+	"fmt"
 	"sort"
 
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
@@ -37,6 +38,14 @@ func (s *TaskRunListSortByCompletion) Len() int {
 func (s *TaskRunListSortByCompletion) Less(i, j int) bool {
 	iTime := s.Items[i].Status.CompletionTime
 	jTime := s.Items[j].Status.CompletionTime
+
+	// if the time is the same then sort by namespace/name for the stable sort
+	// sorted by namespace/name because taskRun may come from different namespace
+	if jTime.Equal(iTime) {
+		iName := fmt.Sprintf("%s/%s", s.Items[i].Namespace, s.Items[i].Name)
+		jName := fmt.Sprintf("%s/%s", s.Items[j].Namespace, s.Items[j].Name)
+		return iName > jName
+	}
 	return jTime.Before(iTime)
 }
 

--- a/tekton/taskrun_test.go
+++ b/tekton/taskrun_test.go
@@ -30,7 +30,7 @@ import (
 
 var _ = Describe("taskRunSortDESCByCompleted", func() {
 	var (
-		taskRunEarly, taskRun, taskRunLate pipelinev1beta1.TaskRun
+		taskRunEarly, taskRun, taskRunLater, taskRunLaterDiffName pipelinev1beta1.TaskRun
 
 		taskRunList pipelinev1beta1.TaskRunList
 
@@ -55,20 +55,23 @@ var _ = Describe("taskRunSortDESCByCompleted", func() {
 
 		taskRunEarly = taskRunConstruct("early", metav1.Time{Time: completeTimeEarly})
 		taskRun = taskRunConstruct("now", metav1.Time{Time: completeTime})
-		taskRunLate = taskRunConstruct("late", metav1.Time{Time: completeTimeLate})
+		taskRunLater = taskRunConstruct("later", metav1.Time{Time: completeTimeLate})
+		taskRunLaterDiffName = taskRunConstruct("later-different-name", metav1.Time{Time: completeTimeLate})
 
 		taskRunList.Items = append(taskRunList.Items, taskRunEarly)
-		taskRunList.Items = append(taskRunList.Items, taskRunLate)
 		taskRunList.Items = append(taskRunList.Items, taskRun)
+		taskRunList.Items = append(taskRunList.Items, taskRunLater)
+		taskRunList.Items = append(taskRunList.Items, taskRunLaterDiffName)
 
 	})
 
 	Context("should return taskRun list", func() {
 		It("by completedTime desc", func() {
 			SortTaskRunByCompletion(&taskRunList)
-			Expect(taskRunList.Items[0].Name).To(Equal("late"))
-			Expect(taskRunList.Items[1].Name).To(Equal("now"))
-			Expect(taskRunList.Items[2].Name).To(Equal("early"))
+			Expect(taskRunList.Items[0].Name).To(Equal("later-different-name"))
+			Expect(taskRunList.Items[1].Name).To(Equal("later"))
+			Expect(taskRunList.Items[2].Name).To(Equal("now"))
+			Expect(taskRunList.Items[3].Name).To(Equal("early"))
 		})
 	})
 


### PR DESCRIPTION
TaskRun sort by completed time but if time is same then the sort is not stable.

So if time is same then compare the namespace and name.

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!--
Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)!

-->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [`spec` PR link](https://github.com/katanomi/spec) included
- [ ] Follows the [commit message standard](https://github.com/katanomi/spec/blob/main/CONTRIBUTING.md#commits)
- [ ] Meets the [contributing guidelines](https://github.com/katanomi/spec/blob/main/CONTRIBUTING.md) (including
  functionality, content, code)
- [ ] Test cases with documentation and functionality works as expected using current and related github repos (MUST deploy and check)
- [ ] Release notes block below has been filled in or deleted (only if no user facing changes)

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->