### PR TITLE
chore: add global credentials namespace key

### DIFF
--- a/config/feature_flags.go
+++ b/config/feature_flags.go
@@ -83,6 +83,9 @@ const (
 
 	// HubResolverFeatureKey indicates the configuration key of the hub resolver feature gate.
 	HubResolverFeatureKey = "hubResolver.enabled"
+
+	// GlobalCredentialNamespaceKey is the key of the global credentials namespace
+	GlobalCredentialNamespaceKey = "globalCredentials.namespace"
 )
 
 const (


### PR DESCRIPTION
# Changes

chore: add global credentials namespace key

from: https://github.com/katanomi/core/blob/cfdfb89db77e92a5d985ac463c322657e80b6456/pkg/integrations/integrationaddress_dependencies.go#L49-L51

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [`spec` PR link](https://github.com/katanomi/spec) included
- [x] Follows the [commit message standard](https://github.com/katanomi/spec/blob/main/CONTRIBUTING.md#commits)
- [x] Meets the [contributing guidelines](https://github.com/katanomi/spec/blob/main/CONTRIBUTING.md) (including
  functionality, content, code)
- [ ] Test cases with documentation and functionality works as expected using current and related github repos (MUST deploy and check)
- [ ] Release notes block below has been filled in or deleted (only if no user facing changes)
