### PR TITLE
fix(hash): improve error handling in HashFolder function

### DIFF
--- a/hash/hash.go
+++ b/hash/hash.go
@@ -104,12 +104,16 @@ func HashFolder(ctx context.Context, folder string, filters ...HashFolderFilter)
 	digests := make([]digest.Digest, 0, 100)
 	log := logging.FromContext(ctx)
 	err = filepath.WalkDir(folder, func(path string, d fs.DirEntry, err error) (walkErr error) {
+		if err != nil {
+			log.Debugf("walk error for path %s: %q", path, err)
+			return err
+		}
 		for _, filter := range filters {
 			if filter != nil && !filter(ctx, path, d) {
 				return
 			}
 		}
-		if !d.IsDir() {
+		if d != nil && !d.IsDir() {
 			var (
 				link    string
 				data    []byte

--- a/hash/hash_test.go
+++ b/hash/hash_test.go
@@ -521,6 +521,10 @@ func TestHashFolderErrorHandling(t *testing.T) {
 		{
 			name: "file permission denied",
 			setupFunc: func(t *testing.T) (string, func()) {
+				if os.Getuid() == 0 {
+					t.Skip("Skipping permission test when running as root")
+				}
+
 				tmpDir := t.TempDir()
 				testFile := filepath.Join(tmpDir, "unreadable.txt")
 

--- a/hash/hash_test.go
+++ b/hash/hash_test.go
@@ -23,6 +23,7 @@ import (
 	"io/fs"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -490,6 +491,77 @@ func TestIgnoreFilesFilter(t *testing.T) {
 
 			filter := IgnoreFilesFilter(test.ignorePaths...)
 			g.Expect(filter(context.Background(), test.path, nil)).To(gomega.Equal(test.result))
+		})
+	}
+}
+
+func TestHashFolderErrorHandling(t *testing.T) {
+	tests := []struct {
+		name        string
+		setupFunc   func(t *testing.T) (string, func())
+		wantErr     bool
+		errContains string
+	}{
+		{
+			name: "non-existent folder",
+			setupFunc: func(t *testing.T) (string, func()) {
+				return "/non/existent/folder", nil
+			},
+			wantErr:     true,
+			errContains: "no such file or directory",
+		},
+		{
+			name: "empty folder path",
+			setupFunc: func(t *testing.T) (string, func()) {
+				return "", nil
+			},
+			wantErr:     true,
+			errContains: "no such file or directory",
+		},
+		{
+			name: "file permission denied",
+			setupFunc: func(t *testing.T) (string, func()) {
+				tmpDir := t.TempDir()
+				testFile := filepath.Join(tmpDir, "unreadable.txt")
+
+				err := os.WriteFile(testFile, []byte("test content"), 0644)
+				if err != nil {
+					t.Fatal(err)
+				}
+
+				err = os.Chmod(testFile, 0000)
+				if err != nil {
+					t.Fatal(err)
+				}
+
+				return tmpDir, func() {
+					os.Chmod(testFile, 0644)
+				}
+			},
+			wantErr:     true,
+			errContains: "permission denied",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := gomega.NewGomegaWithT(t)
+
+			folder, cleanup := tt.setupFunc(t)
+			if cleanup != nil {
+				defer cleanup()
+			}
+
+			_, err := HashFolder(context.TODO(), folder)
+
+			if tt.wantErr {
+				g.Expect(err).ToNot(gomega.BeNil())
+				if tt.errContains != "" {
+					g.Expect(err.Error()).To(gomega.ContainSubstring(tt.errContains))
+				}
+			} else {
+				g.Expect(err).To(gomega.BeNil())
+			}
 		})
 	}
 }


### PR DESCRIPTION
- Add error check at start of filepath.WalkDir callback
- Add nil check for directory entry to prevent panic
- Add comprehensive test cases for error scenarios
- Handle non-existent folders and file permission errors

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!--
Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)!

-->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [`spec` PR link](https://github.com/katanomi/spec) included
- [ ] Follows the [commit message standard](https://github.com/katanomi/spec/blob/main/CONTRIBUTING.md#commits)
- [ ] Meets the [contributing guidelines](https://github.com/katanomi/spec/blob/main/CONTRIBUTING.md) (including
  functionality, content, code)
- [ ] Test cases with documentation and functionality works as expected using current and related github repos (MUST deploy and check)
- [ ] Release notes block below has been filled in or deleted (only if no user facing changes)

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->